### PR TITLE
Fix handling of ivy.xml by %mvn_artifact

### DIFF
--- a/java-utils/mvn_artifact.py
+++ b/java-utils/mvn_artifact.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Red Hat, Inc.
+# Copyright (c) 2014-2016, Red Hat, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -115,21 +115,19 @@ def is_it_ivy_file(fpath):
     return doc.tag == "ivy-module"
 
 
-def add_artifact_elements(metadata, art, ppath=None, jpath=None):
-    ext_backup = art.extension
+def add_artifact_elements(metadata, art_template, ppath=None, jpath=None):
     for path in [ppath, jpath]:
         if path:
+            art = art_template.copy()
             if path is ppath:
                 if not is_it_ivy_file(ppath):
                     art.extension = "pom"
                 else:
-                    art.extension = os.path.splitext(ppath)[1][1:]
+                    art.extension = "xml"
                     art.properties["type"] = "ivy"
-            else:
-                art.extension = ext_backup
 
             art.path = os.path.abspath(path)
-            metadata.artifacts.append(art.copy())
+            metadata.artifacts.append(art)
 
 
 def merge_sections(main, update):

--- a/python/javapackages/common/binding.py
+++ b/python/javapackages/common/binding.py
@@ -126,7 +126,7 @@ def to_element(obj, name=None, type_spec=None, ns=None):
         return element
     if isinstance(obj, dict):
         element = _make_element(name, ns=ns)
-        for key, value in obj.items():
+        for key, value in sorted(obj.items()):
             # TODO rly?
             # entry = _make_element(key, ns=ns)
             entry = _make_element(key)

--- a/test/data/mvn_artifact/args4j.ivy
+++ b/test/data/mvn_artifact/args4j.ivy
@@ -1,0 +1,11 @@
+<ivy-module version="1.0">
+  <info module="args4j" organisation="args4j" revision="2.0.16" status="release"/>
+  <configurations>
+    <conf name="default"/>
+    <conf name="provided"/>
+    <conf name="test"/>
+  </configurations>
+  <publications>
+    <artifact name="args4j" type="jar"/>
+  </publications>
+</ivy-module>

--- a/test/data/mvn_artifact/test_ivy-want.xml
+++ b/test/data/mvn_artifact/test_ivy-want.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<ns1:metadata xmlns:ns1="http://fedorahosted.org/xmvn/METADATA/2.3.0">
+   <ns1:artifacts>
+      <ns1:artifact>
+         <ns1:groupId>args4j</ns1:groupId>
+         <ns1:artifactId>args4j</ns1:artifactId>
+         <ns1:extension>xml</ns1:extension>
+         <ns1:version>2.0.16</ns1:version>
+         <ns1:path>%s/args4j.ivy</ns1:path>
+         <ns1:properties>
+           <type>ivy</type>
+           <xmvn.resolver.disableEffectivePom>true</xmvn.resolver.disableEffectivePom>
+         </ns1:properties>
+      </ns1:artifact>
+   </ns1:artifacts>
+</ns1:metadata>

--- a/test/data/mvn_artifact/test_ivy_jar-want.xml
+++ b/test/data/mvn_artifact/test_ivy_jar-want.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<ns1:metadata xmlns:ns1="http://fedorahosted.org/xmvn/METADATA/2.3.0">
+   <ns1:artifacts>
+      <ns1:artifact>
+         <ns1:groupId>args4j</ns1:groupId>
+         <ns1:artifactId>args4j</ns1:artifactId>
+         <ns1:extension>xml</ns1:extension>
+         <ns1:version>2.0.16</ns1:version>
+         <ns1:path>%s/args4j.ivy</ns1:path>
+         <ns1:properties>
+           <type>ivy</type>
+           <xmvn.resolver.disableEffectivePom>true</xmvn.resolver.disableEffectivePom>
+         </ns1:properties>
+      </ns1:artifact>
+      <ns1:artifact>
+         <ns1:groupId>args4j</ns1:groupId>
+         <ns1:artifactId>args4j</ns1:artifactId>
+         <ns1:extension>jar</ns1:extension>
+         <ns1:version>2.0.16</ns1:version>
+         <ns1:path>%s/maven-artifact.jar</ns1:path>
+         <ns1:properties>
+           <xmvn.resolver.disableEffectivePom>true</xmvn.resolver.disableEffectivePom>
+         </ns1:properties>
+      </ns1:artifact>
+   </ns1:artifacts>
+</ns1:metadata>

--- a/test/data/mvn_artifact/test_ivy_war-want.xml
+++ b/test/data/mvn_artifact/test_ivy_war-want.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<ns1:metadata xmlns:ns1="http://fedorahosted.org/xmvn/METADATA/2.3.0">
+   <ns1:artifacts>
+      <ns1:artifact>
+         <ns1:groupId>args4j</ns1:groupId>
+         <ns1:artifactId>args4j</ns1:artifactId>
+         <ns1:extension>xml</ns1:extension>
+         <ns1:version>2.0.16</ns1:version>
+         <ns1:path>%s/args4j.ivy</ns1:path>
+         <ns1:properties>
+           <type>ivy</type>
+           <xmvn.resolver.disableEffectivePom>true</xmvn.resolver.disableEffectivePom>
+         </ns1:properties>
+      </ns1:artifact>
+      <ns1:artifact>
+         <ns1:groupId>args4j</ns1:groupId>
+         <ns1:artifactId>args4j</ns1:artifactId>
+         <ns1:extension>war</ns1:extension>
+         <ns1:version>2.0.16</ns1:version>
+         <ns1:path>%s/webapp.war</ns1:path>
+         <ns1:properties>
+           <xmvn.resolver.disableEffectivePom>true</xmvn.resolver.disableEffectivePom>
+         </ns1:properties>
+      </ns1:artifact>
+   </ns1:artifacts>
+</ns1:metadata>

--- a/test/mvn_artifact_test.py
+++ b/test/mvn_artifact_test.py
@@ -69,6 +69,24 @@ class TestMvnArtifact(unittest.TestCase):
         report = self.check_result(inspect.currentframe().f_code.co_name)
         self.assertEqual(report, '', report)
 
+    @mvn_artifact('args4j.ivy')
+    def test_ivy(self, stdout, stderr, return_value):
+        self.assertEqual(return_value, 0, stderr)
+        report = self.check_result(inspect.currentframe().f_code.co_name)
+        self.assertEqual(report, '', report)
+
+    @mvn_artifact('args4j.ivy', 'maven-artifact.jar')
+    def test_ivy_jar(self, stdout, stderr, return_value):
+        self.assertEqual(return_value, 0, stderr)
+        report = self.check_result(inspect.currentframe().f_code.co_name)
+        self.assertEqual(report, '', report)
+
+    @mvn_artifact('args4j.ivy', 'webapp.war')
+    def test_ivy_war(self, stdout, stderr, return_value):
+        self.assertEqual(return_value, 0, stderr)
+        report = self.check_result(inspect.currentframe().f_code.co_name)
+        self.assertEqual(report, '', report)
+
     @mvn_artifact('a:b:12', 'test.jar')
     def test_mvn_spec_jar(self, stdout, stderr, return_value):
         self.assertEqual(return_value, 0, stderr)


### PR DESCRIPTION
ivy.xml files had wrong extension ("ivy" instead of "xml").
JAR files had incorrect type "ivy".