### PR TITLE
GitHub migration

### DIFF
--- a/make_release
+++ b/make_release
@@ -43,17 +43,8 @@ git archive -v --prefix="javapackages-$last_tag/" $last_tag | xz > \
     javapackages-$last_tag.tar.xz
 
 
-# run testsuite before allowing upload/final release
+# run testsuite before allowing final release
 if ! ./check; then
     echo "Tests failed, release aborted"
     exit 1
 fi
-
-read -i 'n' -e -p "Do you want to upload file javapackages-$last_tag.tar.xz to fedorahosted? (y/n): "
-
-if [ "$REPLY" = "y" ];then
-    git push --tags
-    scp javapackages-$last_tag.tar.xz fedorahosted.org:javapackages
-fi
-
-

--- a/man/abs2rel.txt
+++ b/man/abs2rel.txt
@@ -26,5 +26,5 @@ EXAMPLES
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.

--- a/man/build-classpath.txt
+++ b/man/build-classpath.txt
@@ -46,8 +46,8 @@ Originally written by David Walluck.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/build-jar-repository.txt
+++ b/man/build-jar-repository.txt
@@ -65,8 +65,8 @@ Originally written by Nicholas Mailhot and David Walluck.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/find-jar.txt
+++ b/man/find-jar.txt
@@ -38,8 +38,8 @@ output.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/gradle_build.txt
+++ b/man/gradle_build.txt
@@ -74,8 +74,8 @@ Written by Mikolaj Izdebski.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/mvn_alias.txt
+++ b/man/mvn_alias.txt
@@ -51,8 +51,8 @@ Versions 3.0.0 and later were written by Stanislav Ochotnicky.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/mvn_artifact.txt
+++ b/man/mvn_artifact.txt
@@ -54,8 +54,8 @@ Written by Michal Srb.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/mvn_build.txt
+++ b/man/mvn_build.txt
@@ -80,8 +80,8 @@ Versions 3.0.0 and later were written by Stanislav Ochotnicky.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/mvn_compat_version.txt
+++ b/man/mvn_compat_version.txt
@@ -46,8 +46,8 @@ Written by Stanislav Ochotnicky.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/mvn_config.txt
+++ b/man/mvn_config.txt
@@ -37,8 +37,8 @@ Versions 3.0.0 and later were written by Stanislav Ochotnicky.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/mvn_file.txt
+++ b/man/mvn_file.txt
@@ -59,8 +59,8 @@ Versions 3.0.0 and later were written by Stanislav Ochotnicky.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/mvn_install.txt
+++ b/man/mvn_install.txt
@@ -44,8 +44,8 @@ Written by Mikolaj Izdebski.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/mvn_package.txt
+++ b/man/mvn_package.txt
@@ -50,8 +50,8 @@ Versions 3.0.0 and later were written by Stanislav Ochotnicky.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/pom_add_dep.txt
+++ b/man/pom_add_dep.txt
@@ -61,8 +61,8 @@ Written by Mikolaj Izdebski.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/pom_add_parent.txt
+++ b/man/pom_add_parent.txt
@@ -37,8 +37,8 @@ Written by Mikolaj Izdebski.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/pom_add_plugin.txt
+++ b/man/pom_add_plugin.txt
@@ -47,8 +47,8 @@ Written by Mikolaj Izdebski.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/pom_change_dep.txt
+++ b/man/pom_change_dep.txt
@@ -60,8 +60,8 @@ Written by Michael Simacek.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/pom_disable_module.txt
+++ b/man/pom_disable_module.txt
@@ -36,8 +36,8 @@ Written by Mikolaj Izdebski.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/pom_remove_dep.txt
+++ b/man/pom_remove_dep.txt
@@ -66,8 +66,8 @@ Written by Mikolaj Izdebski.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/pom_remove_parent.txt
+++ b/man/pom_remove_parent.txt
@@ -33,8 +33,8 @@ Written by Mikolaj Izdebski.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/pom_remove_plugin.txt
+++ b/man/pom_remove_plugin.txt
@@ -50,8 +50,8 @@ Written by Mikolaj Izdebski.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/pom_set_parent.txt
+++ b/man/pom_set_parent.txt
@@ -39,8 +39,8 @@ Written by Mikolaj Izdebski.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/pom_xpath_disable.txt
+++ b/man/pom_xpath_disable.txt
@@ -46,8 +46,8 @@ Written by Michael Simacek.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/pom_xpath_inject.txt
+++ b/man/pom_xpath_inject.txt
@@ -54,8 +54,8 @@ Written by Mikolaj Izdebski.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/pom_xpath_remove.txt
+++ b/man/pom_xpath_remove.txt
@@ -69,8 +69,8 @@ Written by Mikolaj Izdebski.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/pom_xpath_replace.txt
+++ b/man/pom_xpath_replace.txt
@@ -58,8 +58,8 @@ Written by Mikolaj Izdebski.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/pom_xpath_set.txt
+++ b/man/pom_xpath_set.txt
@@ -47,8 +47,8 @@ Written by Mikolaj Izdebski.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/rebuild-jar-repository.txt
+++ b/man/rebuild-jar-repository.txt
@@ -53,8 +53,8 @@ Written by the JPackage Project (http://www.jpackage.org/).
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.
 
 SEE ALSO
 --------

--- a/man/shade-jar.txt
+++ b/man/shade-jar.txt
@@ -40,5 +40,5 @@ Written by Mikolaj Izdebski.
 
 REPORTING BUGS
 --------------
-Bugs should be reported through Red Hat Bugzilla at
-http://bugzilla.redhat.com/.
+Bugs should be reported through Java Pacakges Tools issue tracker at
+Github: https://github.com/fedora-java/javapackages/issues.

--- a/python/setup.py
+++ b/python/setup.py
@@ -15,10 +15,10 @@ setup(
                 "files for Java packaging in Linux distributions",
     version=__version__,
     license="BSD",
-    download_url="https://fedorahosted.org/released/javapackages/",
-    url="https://git.fedorahosted.org/git/javapackages.git",
+    download_url="https://github.com/fedora-java/javapackages/releases",
+    url="https://github.com/fedora-java/javapackages",
     packages=find_packages(exclude=["test"]),
     test_suite="test",
     maintainer="javapackages maintainers",
-    maintainer_email="java-devel@lists.fedoraproject.org"
+    maintainer_email="javapackages-tools-owner@fedoraproject.org"
 )


### PR DESCRIPTION
Finish migration to Github:
- Update bug reporting instructions in man pages.
- Update upstream information in setup.py (java-devel mailing list should not be used as posting to it requires subscription).
- Don't upload release tarballs to fedorahosted.org.