### PR TITLE
Discontinue testing on Python 3.3 and 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: python
 python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
+  - 2.6  # RHEL 6
+  - 2.7  # RHEL 7
+  - 3.5  # Fedora 24+
 sudo: required
 before_install:
   - sudo apt-get -qq update


### PR DESCRIPTION
Python 3.3 was available in Fedora 18 through 20.
Python 3.4 was available in Fedora 21 through 23.
We don't need to care about these targets any longer.