### PR TITLE
Fix scl calling depgenerator from base system

### DIFF
--- a/javapackages-tools.spec
+++ b/javapackages-tools.spec
@@ -156,7 +156,7 @@ sed -e 's/.[17]$/&.gz/' -e 's/.py$/&*/' -i files-*
   mv %{buildroot}%{_root_prefix}/lib/rpm/fileattrs/javadoc{,.%{scl}}.attr
   sed -i 's:\(macros\.\)\(fjava\|jpackage\):\1%{scl}.\2:' files-*
   sed -i 's:\(maven\|osgi\|javadoc\)\.\(req\|prov\|attr\):\1.%{scl}.\2:' \
-      files-* %{buildroot}%{_root_prefix}/lib/rpm/*.{req,prov}
+      files-* %{buildroot}%{_root_prefix}/lib/rpm/*{.req,.prov,fileattrs/*}
 }
 
 %if %{without gradle}


### PR DESCRIPTION
Commit 52504811 introduced a regression that requires generator was
called from base system, instead of scl, due to incorrect path in attr
file. This should fix the problem.