### PR TITLE
Add macro to simplify making dependent collections

### DIFF
--- a/build
+++ b/build
@@ -37,6 +37,7 @@ if ! test -f config.status; then
     exit 1
 fi
 . ./config.status
+. ./expand.sh
 
 rm -rf target
 mkdir target
@@ -48,38 +49,12 @@ manpage()
     (cd ./target && xmlto man --skip-validation "${1}.xml")
 }
 
-expand()
-{
-    local target
-    if [[ -n "${2}" ]]; then
-	target="${2}"
-    else
-	target=$(basename "${1}")
-    fi
-
-    sed \
-        -e "s|@{scl}|${scl}|g" \
-        -e "s|@{scl_root}|${scl_root}|g" \
-        -e "s|@{scl_root_relative}|${scl_root_relative}|g" \
-        -e "s|@{bindir}|${bindir}|g" \
-        -e "s|@{datadir}|${datadir}|g" \
-        -e "s|@{javaconfdir}|${javaconfdir}|g" \
-        -e "s|@{javadir}|${javadir}|g" \
-        -e "s|@{jnidir}|${jnidir}|g" \
-        -e "s|@{jvmdir}|${jvmdir}|g" \
-        -e "s|@{m2home}|${m2home}|g" \
-        -e "s|@{prefix}|${prefix}|g" \
-        -e "s|@{rundir}|${rundir}|g" \
-        -e "s|@{sysconfdir}|${sysconfdir}|g" \
-        -e "s|@{pyinterpreter}|${pyinterpreter}|g" \
-        -e "s|@{abrtlibdir}|${abrtlibdir}|g" \
-        "${1}" >target/"${target}"
-}
-
 if [[ -n "${scl}" ]]; then
-    expand configs/configuration-SCL.xml configuration.xml
-    expand etc/javapackages-config-SCL.json javapackages-config.json
-    expand etc/javapackages-metadata-SCL.xml javapackages-metadata.xml
+    expand configs/configuration-SCL.xml target/configuration.xml
+    expand etc/javapackages-config-SCL.json target/javapackages-config.json
+    expand etc/javapackages-metadata-SCL.xml target/javapackages-metadata.xml
+    sed "s:macros\.d/macros\.jpackage:${root_sysconfdir}/rpm/macros.x-${scl}.jpackage:" configure-base.sh > target/configure-base.sh
+    expand macros.d/macros.scl-java-template
 else
     cat configs/configuration.xml >target/configuration.xml
     cat etc/javapackages-config.json >target/javapackages-config.json
@@ -112,6 +87,8 @@ expand depgenerators/javadoc.req
 expand depgenerators/fileattrs/osgi.attr
 expand depgenerators/fileattrs/maven.attr
 expand depgenerators/fileattrs/javadoc.attr
+
+sed "s:macros\.d/macros\.jpackage:${rpmconfigdir}/&:" configure-base.sh > target/configure-base.sh
 
 manpage abs2rel
 manpage find-jar

--- a/build
+++ b/build
@@ -53,7 +53,7 @@ if [[ -n "${scl}" ]]; then
     expand configs/configuration-SCL.xml target/configuration.xml
     expand etc/javapackages-config-SCL.json target/javapackages-config.json
     expand etc/javapackages-metadata-SCL.xml target/javapackages-metadata.xml
-    sed "s:macros\.d/macros\.jpackage:${root_sysconfdir}/rpm/macros.x-${scl}.jpackage:" configure-base.sh > target/configure-base.sh
+    sed "s:macros\.d/macros\.jpackage:${rpmmacrodir}/macros.x-${scl}.jpackage:" configure-base.sh > target/configure-base.sh
     expand macros.d/macros.scl-java-template
 else
     cat configs/configuration.xml >target/configuration.xml
@@ -87,8 +87,6 @@ expand depgenerators/javadoc.req
 expand depgenerators/fileattrs/osgi.attr
 expand depgenerators/fileattrs/maven.attr
 expand depgenerators/fileattrs/javadoc.attr
-
-sed "s:macros\.d/macros\.jpackage:${rpmconfigdir}/&:" configure-base.sh > target/configure-base.sh
 
 manpage abs2rel
 manpage find-jar

--- a/configure-base.sh
+++ b/configure-base.sh
@@ -2,6 +2,7 @@ vars="
 scl
 scl_root
 scl_root_relative
+scl_suffix
 
 bindir
 datadir
@@ -10,7 +11,9 @@ mandir
 prefix
 rundir
 sysconfdir
+root_sysconfdir
 rpmconfigdir
+rpmmacrodir
 
 m2home
 
@@ -44,7 +47,9 @@ test -z "${localstatedir}" && localstatedir="${prefix}/var"
 test -z "${mandir}" && mandir="${datadir}/man"
 test -z "${rundir}" && rundir="${localstatedir}/run"
 test -z "${sysconfdir}" && sysconfdir="${prefix}/etc"
+test -z "${root_sysconfdir}" && root_sysconfdir="${prefix}/etc"
 test -z "${rpmconfigdir}" && rpmconfigdir="${prefix}/lib/rpm"
+test -z "${rpmmacrodir}" && rpmmacrodir="${rpmconfigdir}/macros.d"
 
 test -z "${m2home}" && m2home="${datadir}/xmvn"
 test -z "${pyinterpreter}" && pyinterpreter=$(which python)
@@ -53,4 +58,5 @@ test -z "${abrtlibdir}" && abrtlibdir="${prefix}/lib/abrt-java-connector"
 eval $(sed -n 's/^%_\('"$vars_re"'\)\ *\(.*\)$/\1="\2"/;T;s/%{_\(.*}\)/${\1/;p' macros.d/macros.jpackage)
 
 test -z "${scl_root_relative}" -a -n "${scl_root}" && scl_root_relative=$(sed "s:^/*::" <<<"${scl_root}")
+scl_suffix="${scl:+.$scl}"
 return 0

--- a/configure-base.sh
+++ b/configure-base.sh
@@ -1,0 +1,56 @@
+vars="
+scl
+scl_root
+scl_root_relative
+
+bindir
+datadir
+localstatedir
+mandir
+prefix
+rundir
+sysconfdir
+rpmconfigdir
+
+m2home
+
+javaconfdir
+javadir
+javadocdir
+jnidir
+jvmcommondatadir
+jvmcommonlibdir
+jvmcommonsysconfdir
+jvmdatadir
+jvmdir
+jvmlibdir
+jvmprivdir
+jvmsysconfdir
+mavenpomdir
+ivyxmldir
+pyinterpreter
+abrtlibdir
+"
+
+vars_re=$(echo $vars | sed 's/ /\\|/g')
+
+eval $(for _; do echo "$_"; done |
+    sed -n 's/^--\('"$vars_re"'\)=\(.*\)$/\1="\2"/;T;p')
+
+test -z "${prefix}" && prefix="/usr/local"
+test -z "${bindir}" && bindir="${prefix}/bin"
+test -z "${datadir}" && datadir="${prefix}/share"
+test -z "${localstatedir}" && localstatedir="${prefix}/var"
+test -z "${mandir}" && mandir="${datadir}/man"
+test -z "${rundir}" && rundir="${localstatedir}/run"
+test -z "${sysconfdir}" && sysconfdir="${prefix}/etc"
+test -z "${rpmconfigdir}" && rpmconfigdir="${prefix}/lib/rpm"
+
+test -z "${m2home}" && m2home="${datadir}/xmvn"
+test -z "${pyinterpreter}" && pyinterpreter=$(which python)
+test -z "${abrtlibdir}" && abrtlibdir="${prefix}/lib/abrt-java-connector"
+
+eval $(sed -n 's/^%_\('"$vars_re"'\)\ *\(.*\)$/\1="\2"/;T;s/%{_\(.*}\)/${\1/;p' macros.d/macros.jpackage)
+
+test -z "${scl_root_relative}" -a -n "${scl_root}" && scl_root_relative=$(sed "s:^/*::" <<<"${scl_root}")
+return 0

--- a/depgenerators/fileattrs/javadoc.attr
+++ b/depgenerators/fileattrs/javadoc.attr
@@ -1,3 +1,3 @@
-%__javadoc_requires	%{?scl:@{javadir}-utils/scl-enable %{?scl_maven} %{scl} -- }%{_rpmconfigdir}/javadoc.req
+%__javadoc_requires	%{?scl:@{javadir}-utils/scl-enable %{?scl_maven} %{scl} -- }%{_rpmconfigdir}/javadoc@{scl_suffix}.req
 %__javadoc_requires_opts %{?scl:--scl %{?scl}}
 %__javadoc_path	^%{_javadocdir}/.[^/]*$

--- a/depgenerators/fileattrs/maven.attr
+++ b/depgenerators/fileattrs/maven.attr
@@ -1,5 +1,5 @@
-%__maven_provides	%{?scl:@{javadir}-utils/scl-enable %{?scl_maven} %{scl} -- }%{_rpmconfigdir}/maven.prov
+%__maven_provides	%{?scl:@{javadir}-utils/scl-enable %{?scl_maven} %{scl} -- }%{_rpmconfigdir}/maven@{scl_suffix}.prov
 %__maven_provides_opts	--cachedir %{_builddir}/%{?buildsubdir} --rpm-pid %{lua:print(math.floor(posix.getprocessid("pid")))} %{?scl:--scl %{?scl}}
-%__maven_requires	%{?scl:@{javadir}-utils/scl-enable %{?scl_maven} %{scl} -- }%{_rpmconfigdir}/maven.req
+%__maven_requires	%{?scl:@{javadir}-utils/scl-enable %{?scl_maven} %{scl} -- }%{_rpmconfigdir}/maven@{scl_suffix}.req
 %__maven_requires_opts	--cachedir %{_builddir}/%{?buildsubdir} --rpm-pid %{lua:print(math.floor(posix.getprocessid("pid")))} %{?scl:--scl %{?scl}}
 %__maven_path	^%{_datadir}/maven-metadata/.*

--- a/depgenerators/fileattrs/osgi.attr
+++ b/depgenerators/fileattrs/osgi.attr
@@ -1,5 +1,5 @@
-%__osgi_provides	%{?scl:@{javadir}-utils/scl-enable %{?scl_maven} %{scl} -- }%{_rpmconfigdir}/osgi.prov
+%__osgi_provides	%{?scl:@{javadir}-utils/scl-enable %{?scl_maven} %{scl} -- }%{_rpmconfigdir}/osgi@{scl_suffix}.prov
 %__osgi_provides_opts	--cachedir %{_builddir}/%{?buildsubdir} --rpm-pid %{lua:print(math.floor(posix.getprocessid("pid")))} %{?scl:--scl %{?scl}}
-%__osgi_requires	%{!?scl:%{_rpmconfigdir}/osgi.req}%{?scl:%{_root_bindir}/true}
+%__osgi_requires	%{!?scl:%{_rpmconfigdir}/osgi@{scl_suffix}.req}%{?scl:%{_root_bindir}/true}
 %__osgi_requires_opts	--cachedir %{_builddir}/%{?buildsubdir} --rpm-pid %{lua:print(math.floor(posix.getprocessid("pid")))} %{?scl:--scl %{?scl}}
 %__osgi_path	^(.*\\.jar|((%{_prefix}/lib(64)?|%{_datadir})/.*/META-INF/MANIFEST.MF))$

--- a/expand.sh
+++ b/expand.sh
@@ -42,6 +42,7 @@ expand()
         -e "s|@{scl}|${scl}|g" \
         -e "s|@{scl_root}|${scl_root}|g" \
         -e "s|@{scl_root_relative}|${scl_root_relative}|g" \
+        -e "s|@{scl_suffix}|${scl_suffix}|g" \
         -e "s|@{bindir}|${bindir}|g" \
         -e "s|@{datadir}|${datadir}|g" \
         -e "s|@{javaconfdir}|${javaconfdir}|g" \

--- a/expand.sh
+++ b/expand.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright (c) 2013-2017 Red Hat, Inc.
 # All rights reserved.
 #
@@ -30,8 +29,30 @@
 #
 # Authors: Mikolaj Izdebski <mizdebsk@redhat.com>
 
-set -e
+expand()
+{
+    local target
+    if [[ -n "${2}" ]]; then
+        target="${2}"
+    else
+        target=target/$(basename "${1}")
+    fi
 
-. ./configure-base.sh
-
-set | sed -n 's/^\('"$vars_re"'\)=/&/;T;p' >config.status
+    sed \
+        -e "s|@{scl}|${scl}|g" \
+        -e "s|@{scl_root}|${scl_root}|g" \
+        -e "s|@{scl_root_relative}|${scl_root_relative}|g" \
+        -e "s|@{bindir}|${bindir}|g" \
+        -e "s|@{datadir}|${datadir}|g" \
+        -e "s|@{javaconfdir}|${javaconfdir}|g" \
+        -e "s|@{javadir}|${javadir}|g" \
+        -e "s|@{jnidir}|${jnidir}|g" \
+        -e "s|@{jvmdir}|${jvmdir}|g" \
+        -e "s|@{m2home}|${m2home}|g" \
+        -e "s|@{prefix}|${prefix}|g" \
+        -e "s|@{rundir}|${rundir}|g" \
+        -e "s|@{sysconfdir}|${sysconfdir}|g" \
+        -e "s|@{pyinterpreter}|${pyinterpreter}|g" \
+        -e "s|@{abrtlibdir}|${abrtlibdir}|g" \
+        "${1}" >"${target}"
+}

--- a/install
+++ b/install
@@ -58,8 +58,8 @@ link()
 inst()
 {
     install -d -m 755 "${DEST}/${3}"
-    install -p -m 644 "${2}" "${DEST}/${3}/"
-    echo "${1} ${3}/"$(basename "${2}")
+    install -p -m 644 "${2}" "${DEST}/${3}/${4}"
+    echo "${1} ${3}/${4:-$(basename "${2}")}"
 }
 
 inst_data() { inst "%attr(0644,root,root)" "${@}"; }
@@ -100,9 +100,9 @@ dir "${datadir}/eclipse"
 dir "${datadir}/eclipse/dropins"
 dir "${datadir}/eclipse/droplets"
 dir "${rpmconfigdir}"
-dir "${rpmconfigdir}/macros.d"
+dir "${rpmconfigdir}"
 if [[ -n "${scl}" ]]; then
-dir "${javadir}-utils/scl-template"
+    dir "${javadir}-utils/scl-template"
 fi
 
 inst_exec target/build-classpath "${bindir}"
@@ -124,7 +124,10 @@ inst_data target/java-functions "${javadir}-utils"
 inst_exec java-utils/java-wrapper "${javadir}-utils"
 inst_exec java-utils/scl-enable "${javadir}-utils"
 
-inst_data target/macros.jpackage "${rpmconfigdir}/macros.d"
+if [[ -z "${scl}" ]]; then
+    # in scl, macros.jpackage is installed in javapackages-local
+    inst_data target/macros.jpackage "${rpmmacrodir}"
+fi
 
 inst_data target/build-classpath.1 "${mandir}/man1"
 inst_data target/build-jar-repository.1 "${mandir}/man1"
@@ -138,14 +141,12 @@ inst_data target/configuration.xml "${m2home}"
 
 
 if [[ -n "${scl}" ]]; then
-inst_data target/configure-base.sh "${javadir}-utils/scl-template"
-inst_data expand.sh "${javadir}-utils/scl-template"
-inst_data configs/configuration-SCL.xml "${javadir}-utils/scl-template"
-inst_data etc/javapackages-config-SCL.json "${javadir}-utils/scl-template"
-inst_data etc/java.conf "${javadir}-utils/scl-template"
-inst_data etc/eclipse.conf "${javadir}-utils/scl-template"
-
-inst_data macros.d/macros.scl-java-template "${rpmconfigdir}/macros.d"
+    inst_data target/configure-base.sh "${javadir}-utils/scl-template"
+    inst_data expand.sh "${javadir}-utils/scl-template"
+    inst_data configs/configuration-SCL.xml "${javadir}-utils/scl-template"
+    inst_data etc/javapackages-config-SCL.json "${javadir}-utils/scl-template"
+    inst_data etc/java.conf "${javadir}-utils/scl-template"
+    inst_data etc/eclipse.conf "${javadir}-utils/scl-template"
 fi
 
 if [ -z "$pyinterpreter" ]; then
@@ -175,15 +176,15 @@ inst_data java-utils/mvn_file.py "${javadir}-utils"
 inst_data java-utils/mvn_package.py "${javadir}-utils"
 
 if [[ -n "${scl}" ]]; then
-# Base RHEL contains macros in /etc/ that would override ours.
-# We need to place ours there alphabetically after to prevent that.
-# Additionally we move macros.jpackage to javapackages-local, so they don't
-# interfere with base RHEL if only javapackages-tools is installed.
-inst_data target/macros.fjava "${root_sysconfdir}/rpm" "macros.x-${scl}.fjava"
-inst_data target/macros.jpackage "${root_sysconfdir}/rpm" "macros.x-${scl}.jpackage"
-inst_data target/macros.scl-java-template "${rpmconfigdir}/macros.d" "macros.${scl}.scl-java-template"
+    # Base RHEL contains macros in /etc/ that would override ours.
+    # We need to place ours there alphabetically after to prevent that.
+    # Additionally we move macros.jpackage to javapackages-local, so they don't
+    # interfere with base RHEL if only javapackages-tools is installed.
+    inst_data target/macros.fjava "${rpmmacrodir}" "macros.x-${scl}.fjava"
+    inst_data target/macros.jpackage "${rpmmacrodir}" "macros.x-${scl}.jpackage"
+    inst_data target/macros.scl-java-template "${rpmmacrodir}" "macros.${scl}.scl-java-template"
 else
-inst_data target/macros.fjava "${rpmconfigdir}/macros.d"
+    inst_data target/macros.fjava "${rpmmacrodir}"
 fi
 
 inst_data target/abs2rel.1 "${mandir}/man1"
@@ -210,15 +211,15 @@ inst_data target/pom_xpath_remove.7 "${mandir}/man7"
 inst_data target/pom_xpath_replace.7 "${mandir}/man7"
 inst_data target/pom_xpath_set.7 "${mandir}/man7"
 
-inst_exec target/maven.prov "${rpmconfigdir}"
-inst_exec target/maven.req "${rpmconfigdir}"
-inst_exec target/osgi.prov "${rpmconfigdir}"
-inst_exec target/osgi.req "${rpmconfigdir}"
-inst_exec target/javadoc.req "${rpmconfigdir}"
+inst_exec target/maven.prov "${rpmconfigdir}" "maven${scl_suffix}.prov"
+inst_exec target/maven.req "${rpmconfigdir}" "maven${scl_suffix}.req"
+inst_exec target/osgi.prov "${rpmconfigdir}" "osgi${scl_suffix}.prov"
+inst_exec target/osgi.req "${rpmconfigdir}" "osgi${scl_suffix}.req"
+inst_exec target/javadoc.req "${rpmconfigdir}" "javadoc${scl_suffix}.req"
 
-inst_data target/maven.attr "${rpmconfigdir}/fileattrs"
-inst_data target/osgi.attr "${rpmconfigdir}/fileattrs"
-inst_data target/javadoc.attr "${rpmconfigdir}/fileattrs"
+inst_data target/maven.attr "${rpmconfigdir}/fileattrs" "maven${scl_suffix}.attr"
+inst_data target/osgi.attr "${rpmconfigdir}/fileattrs" "osgi${scl_suffix}.attr"
+inst_data target/javadoc.attr "${rpmconfigdir}/fileattrs" "javadoc${scl_suffix}.attr"
 
 inst_config target/javapackages-config.json "${javaconfdir}"
 

--- a/install
+++ b/install
@@ -101,6 +101,9 @@ dir "${datadir}/eclipse/dropins"
 dir "${datadir}/eclipse/droplets"
 dir "${rpmconfigdir}"
 dir "${rpmconfigdir}/macros.d"
+if [[ -n "${scl}" ]]; then
+dir "${javadir}-utils/scl-template"
+fi
 
 inst_exec target/build-classpath "${bindir}"
 inst_exec target/build-classpath-directory "${bindir}"
@@ -133,6 +136,18 @@ inst_data target/find-jar.1 "${mandir}/man1"
 inst_data target/javapackages-metadata.xml "${datadir}/maven-metadata"
 inst_data target/configuration.xml "${m2home}"
 
+
+if [[ -n "${scl}" ]]; then
+inst_data target/configure-base.sh "${javadir}-utils/scl-template"
+inst_data expand.sh "${javadir}-utils/scl-template"
+inst_data configs/configuration-SCL.xml "${javadir}-utils/scl-template"
+inst_data etc/javapackages-config-SCL.json "${javadir}-utils/scl-template"
+inst_data etc/java.conf "${javadir}-utils/scl-template"
+inst_data etc/eclipse.conf "${javadir}-utils/scl-template"
+
+inst_data macros.d/macros.scl-java-template "${rpmconfigdir}/macros.d"
+fi
+
 if [ -z "$pyinterpreter" ]; then
     exit 0
 fi
@@ -159,7 +174,17 @@ inst_data java-utils/mvn_config.py "${javadir}-utils"
 inst_data java-utils/mvn_file.py "${javadir}-utils"
 inst_data java-utils/mvn_package.py "${javadir}-utils"
 
+if [[ -n "${scl}" ]]; then
+# Base RHEL contains macros in /etc/ that would override ours.
+# We need to place ours there alphabetically after to prevent that.
+# Additionally we move macros.jpackage to javapackages-local, so they don't
+# interfere with base RHEL if only javapackages-tools is installed.
+inst_data target/macros.fjava "${root_sysconfdir}/rpm" "macros.x-${scl}.fjava"
+inst_data target/macros.jpackage "${root_sysconfdir}/rpm" "macros.x-${scl}.jpackage"
+inst_data target/macros.scl-java-template "${rpmconfigdir}/macros.d" "macros.${scl}.scl-java-template"
+else
 inst_data target/macros.fjava "${rpmconfigdir}/macros.d"
+fi
 
 inst_data target/abs2rel.1 "${mandir}/man1"
 inst_data target/mvn_alias.7 "${mandir}/man7"

--- a/javapackages-tools.spec
+++ b/javapackages-tools.spec
@@ -17,6 +17,7 @@
 %else
 %global python_prefix python
 %global python_interpreter %{__python2}
+%global rpmmacrodir /etc/rpm
 %endif
 
 
@@ -134,30 +135,14 @@ This package provides non-essential macros and scripts to support Java packaging
 %setup -q -n %{pkg_name}-%{version}
 
 %build
-%configure --pyinterpreter=%{python_interpreter} %{?scl:--rpmconfigdir=%{_root_prefix}/lib/rpm --scl=%{scl} --scl_root=%{_scl_root}}
+%configure --pyinterpreter=%{python_interpreter} --rpmmacrodir=%{rpmmacrodir} %{?scl:--rpmconfigdir=%{_root_prefix}/lib/rpm --scl=%{scl} --scl_root=%{_scl_root}}
 ./build
 
 %install
 ./install
 
-sed -i 's|mvn_build.py|& --xmvn-javadoc|' $(find %{buildroot} -name macros.fjava)
+sed -i 's|mvn_build.py|& --xmvn-javadoc|' $(find %{buildroot} -name 'macros*.fjava')
 sed -e 's/.[17]$/&.gz/' -e 's/.py$/&*/' -i files-*
-
-%{?scl:
-  mv %{buildroot}%{_root_prefix}/lib/rpm/macros.d/macros{,.%{scl}}.fjava
-  mv %{buildroot}%{_root_prefix}/lib/rpm/macros.d/macros{,.%{scl}}.jpackage
-  mv %{buildroot}%{_root_prefix}/lib/rpm/maven{,.%{scl}}.req
-  mv %{buildroot}%{_root_prefix}/lib/rpm/maven{,.%{scl}}.prov
-  mv %{buildroot}%{_root_prefix}/lib/rpm/osgi{,.%{scl}}.req
-  mv %{buildroot}%{_root_prefix}/lib/rpm/osgi{,.%{scl}}.prov
-  mv %{buildroot}%{_root_prefix}/lib/rpm/javadoc{,.%{scl}}.req
-  mv %{buildroot}%{_root_prefix}/lib/rpm/fileattrs/maven{,.%{scl}}.attr
-  mv %{buildroot}%{_root_prefix}/lib/rpm/fileattrs/osgi{,.%{scl}}.attr
-  mv %{buildroot}%{_root_prefix}/lib/rpm/fileattrs/javadoc{,.%{scl}}.attr
-  sed -i 's:\(macros\.\)\(fjava\|jpackage\):\1%{scl}.\2:' files-*
-  sed -i 's:\(maven\|osgi\|javadoc\)\.\(req\|prov\|attr\):\1.%{scl}.\2:' \
-      files-* %{buildroot}%{_root_prefix}/lib/rpm/fileattrs/*
-}
 
 %if %{without gradle}
 rm -rf %{buildroot}%{_bindir}/gradle-local

--- a/macros.d/macros.jpackage
+++ b/macros.d/macros.jpackage
@@ -85,14 +85,14 @@
 #
 # Current default JVM home.
 #
-%java_home      %(. %{_javadir}-utils/java-functions; set_jvm; echo $JAVA_HOME)
+%java_home      %(. @{javadir}-utils/java-functions; set_jvm; echo $JAVA_HOME)
 
 #==============================================================================
 # ---- default Java commands
 
 %ant            JAVA_HOME=%{java_home} %{?scl:@{javadir}-utils/scl-enable %{?scl_maven} %{scl} -- }ant
 %jar            %{java_home}/bin/jar
-%java           %(. %{_javadir}-utils/java-functions; set_javacmd; echo $JAVACMD)
+%java           %(. @{javadir}-utils/java-functions; set_javacmd; echo $JAVACMD)
 %javac          %{java_home}/bin/javac
 %javadoc        %{java_home}/bin/javadoc
 
@@ -119,7 +119,7 @@ cat > %{buildroot}%{_bindir}/%5 << EOF \
 \
 # Source functions library\
 _prefer_jre="%{?6}"\
-. %{_javadir}-utils/java-functions\
+. @{javadir}-utils/java-functions\
 \
 # Source system prefs\
 if [ -f %{_sysconfdir}/java/%{name}.conf ] ; then\

--- a/macros.d/macros.scl-java-template
+++ b/macros.d/macros.scl-java-template
@@ -1,0 +1,68 @@
+# Copyright (c) 2017, Red Hat, Inc
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name of Red Hat nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Authors: Michael Simacek <msimacek@redhat.com>
+
+%scl_install_java \
+( \
+    . @{javadir}-utils/scl-template/configure-base.sh --scl=%{scl} --scl_root=%{_scl_root} \\\
+        --rpmconfigdir=%{_root_prefix}/lib/rpm \\\
+        --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} \
+    . @{javadir}-utils/scl-template/expand.sh \
+    template_config () { \
+        expand "@{javadir}-utils/scl-template/$1" "%{buildroot}$2" \
+        echo "%config(noreplace) $2" >> .java-filelist \
+    } \
+    dir () { \
+        mkdir -p "%{buildroot}/$1"; echo "%dir $1" >> .java-filelist \
+    } \
+    dir "%{_javaconfdir}" \
+    dir "%{_javadir}" \
+    dir "%{_jnidir}" \
+    dir "%{_javadocdir}" \
+    dir "%{_mavenpomdir}" \
+    dir "%{_ivyxmldir}" \
+    dir "%{_sysconfdir}/ivy" \
+    dir "%{_datadir}/maven-metadata" \
+    dir "%{_prefix}/lib/eclipse" \
+    dir "%{_prefix}/lib/eclipse/features" \
+    dir "%{_prefix}/lib/eclipse/plugins" \
+    dir "%{_prefix}/lib/eclipse/dropins" \
+    dir "%{_prefix}/lib/eclipse/droplets" \
+    dir "%{_datadir}/eclipse" \
+    dir "%{_datadir}/eclipse/dropins" \
+    dir "%{_datadir}/eclipse/droplets" \
+    dir "%{_sysconfdir}/xdg" \
+    dir "%{_sysconfdir}/xdg/xmvn" \
+    template_config javapackages-config-SCL.json %{_javaconfdir}/javapackages-config.json \
+    template_config configuration-SCL.xml %{_sysconfdir}/xdg/xmvn/configuration.xml \
+    template_config java.conf %{_javaconfdir}/java.conf \
+    template_config eclipse.conf %{_javaconfdir}/eclipse.conf \
+) \
+%{nil}


### PR DESCRIPTION
The metapackage now only needs:
````
%install
%{scl_install}
%{scl_install_java}
...
%files runtime -f .java-filelist
%{scl_files}
````
Configuration files are installed from templates.
I verified that regular maven builds and installations work, but I still need to check ivy and eclipse.