### PR TITLE
[mvn_artifact] Provide more helpful error messages

### DIFF
--- a/test/mvn_artifact_test.py
+++ b/test/mvn_artifact_test.py
@@ -57,6 +57,18 @@ class TestMvnArtifact(unittest.TestCase):
         report = self.check_result(inspect.currentframe().f_code.co_name)
         self.assertEqual(report, '', report)
 
+    @mvn_artifact('nonexistent.pom', 'maven-artifact.jar')
+    def test_nonexistent(self, stdout, stderr, return_value):
+        self.assertNotEqual(0, return_value)
+        self.assertFalse("Traceback" in stderr)
+        self.assertTrue("existing file" in stderr)
+
+    @mvn_artifact('invalid::artifact', 'maven-artifact.jar')
+    def test_invalid_artifact_string(self, stdout, stderr, return_value):
+        self.assertNotEqual(0, return_value)
+        self.assertFalse("Traceback" in stderr)
+        self.assertTrue("artifactId" in stderr)
+
     @mvn_artifact('args4j.pom', 'maven-artifact.jar')
     def test_basic_jar(self, stdout, stderr, return_value):
         self.assertEqual(return_value, 0, stderr)


### PR DESCRIPTION
This:
````
error: The first argument 'output/dist/lib/asm-all-6.0.pom' doesn't point to an existing file nor it looks like an artifact string
````
is IMO better than this:

````
Traceback (most recent call last):
  File "/usr/share/java-utils/mvn_artifact.py", line 250, in _main
    uart = Artifact.from_mvn_str(args[0])
  File "/usr/lib/python3.6/site-packages/javapackages/maven/artifact.py", line 350, in from_mvn_str
    p = Artifact.get_parts_from_mvn_str(mvnstr)
  File "/usr/lib/python3.6/site-packages/javapackages/maven/artifact.py", line 84, in get_parts_from_mvn_str
    .format(mvnstr=mvnstr))
javapackages.maven.artifact.ArtifactFormatException: Artifact string 'output/dist/lib/asm-all-6.0.pom' does not contain ':' character. Can not parse

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/java-utils/mvn_artifact.py", line 315, in <module>
    _main()
  File "/usr/share/java-utils/mvn_artifact.py", line 259, in _main
    if is_it_ivy_file(args[0]):
  File "/usr/share/java-utils/mvn_artifact.py", line 113, in is_it_ivy_file
    doc = et.parse(fpath)
  File "src/lxml/lxml.etree.pyx", line 1885, in lxml.etree._ElementTree.parse (src/lxml/lxml.etree.c:63960)
  File "src/lxml/parser.pxi", line 1811, in lxml.etree._parseDocument (src/lxml/lxml.etree.c:118635)
  File "src/lxml/parser.pxi", line 1837, in lxml.etree._parseDocumentFromURL (src/lxml/lxml.etree.c:118982)
  File "src/lxml/parser.pxi", line 1741, in lxml.etree._parseDocFromFile (src/lxml/lxml.etree.c:117894)
  File "src/lxml/parser.pxi", line 1138, in lxml.etree._BaseParser._parseDocFromFile (src/lxml/lxml.etree.c:112440)
  File "src/lxml/parser.pxi", line 595, in lxml.etree._ParserContext._handleParseResultDoc (src/lxml/lxml.etree.c:105896)
  File "src/lxml/parser.pxi", line 706, in lxml.etree._handleParseResult (src/lxml/lxml.etree.c:107604)
  File "src/lxml/parser.pxi", line 633, in lxml.etree._raiseParseError (src/lxml/lxml.etree.c:106415)
OSError: Error reading file 'output/dist/lib/asm-all-6.0.pom': failed to load external entity "output/dist/lib/asm-all-6.0.pom"
````