### PR TITLE
[java-functions] Avoid colons in jar names

### DIFF
--- a/bin/rebuild-jar-repository
+++ b/bin/rebuild-jar-repository
@@ -59,7 +59,7 @@ check_java_env || exit 4
 set_jvm_dirs || exit 5
 
 extension_list=$(find $repository -name '\[*\]*.jar' -not -type d | \
-sed 's+\]\[+/+g' | sed 's+.*\[++g' | sed 's+\].*++g' | sort | uniq)
+sed 's+\]\[+/+g' | sed 's+.*\[++g' | sed 's+\].*++g' | sed 's+@+:+g' | sort | uniq)
 
 rm -f $(find $repository -name '\[*\]*.jar' -not -type d)
 

--- a/java-utils/java-functions
+++ b/java-utils/java-functions
@@ -322,6 +322,7 @@ link_jar_repository() {
          [ -z "$_PRESERVE_NAMING" ] \
             && extension=[$(echo $extension | sed 's+/+][+g')] \
             || extension=$(echo $extension | sed 's+/+_+g')
+        extension=$(echo "$extension" | sed 's+:+@+')
          if [ $found -eq 0 ] ; then
             if [ -d "$found_extension" ] ; then
                for jar in $(find "$found_extension" -follow -name "*.jar") ; do


### PR DESCRIPTION
When using artifact coordinates with build-jar-repository, they end up
in the filename. Such jars then cannot be easily put onto classpath.
This replaces colons with double dashes.

Fixes #50