### PR TITLE
Allow specifying custom repo when calling xmvn-install

### DIFF
--- a/macros.d/macros.fjava
+++ b/macros.d/macros.fjava
@@ -153,7 +153,7 @@
 # This macro causes previously built Maven project to be installed into
 # buildroot. It is intended to be placed in %install section of spec file.
 #
-%mvn_install(J:X) %{?scl:@{javadir}-utils/scl-enable %{?scl_maven} %{scl} -- }xmvn-install %{?-X} -R .xmvn-reactor -n %{?scl:%{pkg_name}}%{!?scl:%{name}} -d "%{buildroot}" \
+%mvn_install(J:X) %{?scl:@{javadir}-utils/scl-enable %{?scl_maven} %{scl} -- }xmvn-install %{?-X} -R .xmvn-reactor -n %{?scl:%{pkg_name}}%{!?scl:%{name}} %{?xmvn_install_repo:-i %{xmvn_install_repo}} -d "%{buildroot}" \
 %{-J*:jdir="%{-J*}"}%{!-J*:jdir=target/site/apidocs; [ -d .xmvn/apidocs ] && jdir=.xmvn/apidocs} \
 %{__mkdir_p} %{buildroot}%{_licensedir} \
 if [ -d "${jdir}" ]; then \


### PR DESCRIPTION
This together with https://github.com/fedora-java/xmvn/pull/29 will let us put `xmvn_install_repo` macro in modulemd (of maven module and other modules targeted for use by end users) to specify which repo XMvn should use for artifact installation in a given module build.
Then, javapackages in javapackages-tools module will ship configuration with different repositories for different module-streams it supports building.
Then, module-specific repos will have custom suffixes configured as per https://github.com/fedora-java/xmvn/pull/28