### PR TITLE
Remove resolverSettings/prefixes from XMvn config

### DIFF
--- a/configs/configuration-SCL.xml
+++ b/configs/configuration-SCL.xml
@@ -5,9 +5,6 @@
       <repository>@{scl_root}/usr/share/maven-metadata</repository>
     </metadataRepositories>
     <ignoreDuplicateMetadata>false</ignoreDuplicateMetadata>
-    <prefixes>
-      <prefix>@{scl_root}/</prefix>
-    </prefixes>
   </resolverSettings>
   <installerSettings>
     <metadataDir>@{scl_root_relative}/usr/share/maven-metadata</metadataDir>

--- a/configs/configuration.xml
+++ b/configs/configuration.xml
@@ -4,9 +4,6 @@
     <metadataRepositories>
       <repository>/usr/share/maven-metadata</repository>
     </metadataRepositories>
-    <prefixes>
-      <prefix>/</prefix>
-    </prefixes>
   </resolverSettings>
   <installerSettings>
     <metadataDir>usr/share/maven-metadata</metadataDir>


### PR DESCRIPTION
This XMvn option has been ignored by XMvn for more than 4 years, since
April 2014, when it switched to artifact resolution from metadata
files instead of configured artifact repositories.  Removing this
option from our configs will allow XMvn to eventually deprecate it.