### PR TITLE
Introduce javapackages-filesystem package

### DIFF
--- a/install
+++ b/install
@@ -70,7 +70,8 @@ inst_doc() {
     echo "%doc ${1}"
 }
 
-exec >files-common
+
+exec >files-filesystem
 
 dir "${javaconfdir}"
 dir "${javaconfdir}/security"
@@ -84,13 +85,11 @@ dir "${jvmcommonlibdir}"
 dir "${jvmcommondatadir}"
 dir "${jvmcommonsysconfdir}"
 dir "${javadir}"
-dir "${javadir}-utils"
 dir "${jnidir}"
 dir "${javadocdir}"
 dir "${mavenpomdir}"
 dir "${ivyxmldir}"
 dir "${datadir}/maven-metadata"
-dir "${m2home}"
 dir "${prefix}/lib/eclipse"
 dir "${prefix}/lib/eclipse/features"
 dir "${prefix}/lib/eclipse/plugins"
@@ -99,7 +98,12 @@ dir "${prefix}/lib/eclipse/droplets"
 dir "${datadir}/eclipse"
 dir "${datadir}/eclipse/dropins"
 dir "${datadir}/eclipse/droplets"
-dir "${rpmconfigdir}"
+
+
+exec >files-tools
+
+dir "${m2home}"
+dir "${javadir}-utils"
 dir "${rpmconfigdir}"
 if [[ -n "${scl}" ]]; then
     dir "${javadir}-utils/scl-template"

--- a/javapackages-tools.spec
+++ b/javapackages-tools.spec
@@ -47,14 +47,13 @@ BuildRequires:  %{python_prefix}-setuptools
 BuildRequires:  %{python_prefix}-nose
 BuildRequires:  %{python_prefix}-six
 
+Requires:       %{?scl_prefix}javapackages-filesystem = %{version}-%{release}
 Requires:       coreutils
 Requires:       findutils
 Requires:       which
 # default JRE
 Requires:       java-1.8.0-openjdk-headless
 
-Obsoletes:      %{?scl_prefix}eclipse-filesystem < 2
-Provides:       %{?scl_prefix}eclipse-filesystem = %{version}-%{release}
 Provides:       %{?scl_prefix}jpackage-utils = %{version}-%{release}
 # These could be generated automatically, but then we would need to
 # depend on javapackages-local for dependency generator.
@@ -63,6 +62,15 @@ Provides:       %{?scl_prefix}mvn(sun.jdk:jconsole) = SYSTEM
 
 %description
 This package provides macros and scripts to support Java packaging.
+
+%package -n %{?scl_prefix}javapackages-filesystem
+Summary:        Java packages filesystem layout
+Obsoletes:      %{?scl_prefix}eclipse-filesystem < 2
+Provides:       %{?scl_prefix}eclipse-filesystem = %{version}-%{release}
+
+%description -n %{?scl_prefix}javapackages-filesystem
+This package provides some basic directories into which Java packages
+install their content.
 
 %package -n %{?scl_prefix}maven-local
 Summary:        Macros and scripts for Maven packaging support
@@ -162,7 +170,9 @@ rm -rf %{buildroot}%{_mandir}/man7/gradle_build.7
 ./check
 %endif
 
-%files -f files-common
+%files -f files-tools
+
+%files -n %{?scl_prefix}javapackages-filesystem -f files-filesystem
 
 %files -n %{?scl_prefix}javapackages-local -f files-local
 


### PR DESCRIPTION
JDK packages require javapackages-tools because it owns directories into which JDK install their files. But javapackages-tools requires default system Java (currently java-1.8.0-openjdk-headless). This means that installing non-default JDK (such as 9 or 10) can pull in OpenJDK 8 as a dependency.

This PR attempts to improve the situation by introducing minimal filesystem package, which JDK packages will be able to require instead of javapackages-tools.

CC @judovana