### PR TITLE
[java-functions] extend ABRT Java agent options

### DIFF
--- a/etc/java.conf
+++ b/etc/java.conf
@@ -13,5 +13,5 @@ JNI_LIBDIR=@{jnidir}
 #JAVACMD_OPTS=
 
 # You can disable ABRT Java Connector by setting JAVA_ABRT to "off".
-# See: https://github.com/jfilak/abrt-java-connector/
+# See: https://github.com/abrt/abrt-java-connector/
 #JAVA_ABRT=off

--- a/java-utils/java-functions
+++ b/java-utils/java-functions
@@ -106,12 +106,20 @@ _load_java_conf()
 	JAVACMD_OPTS="${java_opts_save}"
     fi
 
-    if [ "_${JAVA_ABRT}" != "_off" -a -f "@{abrtlibdir}/libabrt-java-connector.so" -a -f "@{rundir}/abrt/abrtd.pid" ]; then
-	_log "ABRT Java connector was enabled"
-	_log "Using ABRT Java agent: @{abrtlibdir}/libabrt-java-connector.so"
-	JAVACMD_OPTS="${JAVACMD_OPTS} -agentpath:@{abrtlibdir}/libabrt-java-connector.so=abrt=on"
+    if [ "_${JAVA_ABRT}" != "_off" -a -f "@{abrtlibdir}/libabrt-java-connector.so" ]; then
+        if [ -f "@{rundir}/abrt/abrtd.pid" ]; then
+            ABRT_JAVA_CONNECTOR_OPTS="abrt=on,"
+        fi
+        if [ -f "@{bindir}/container-exception-logger" ]; then
+            ABRT_JAVA_CONNECTOR_OPTS+="cel=on"
+        fi
+        if [ ! -z ${ABRT_JAVA_CONNECTOR_OPTS} ]; then
+            _log "ABRT Java connector was enabled"
+            _log "Using ABRT Java agent: @{abrtlibdir}/libabrt-java-connector.so=${ABRT_JAVA_CONNECTOR_OPTS}"
+            JAVACMD_OPTS="${JAVACMD_OPTS} -agentpath:@{abrtlibdir}/libabrt-java-connector.so=${ABRT_JAVA_CONNECTOR_OPTS}"
+        fi
     else
-	_log "ABRT Java connector is disabled"
+        _log "ABRT Java connector is disabled"
     fi
 }
 


### PR DESCRIPTION
If ABRT Java agent is enabled and container-exception-logger is
installed, pass cel=on parameter to libabrt-java-connector.so.

Signed-off-by: mhabrnal <mhabrnal@localhost.localdomain>