### PR TITLE
Rename the async kwarg in call_script to wait (reverses the logic)

### DIFF
--- a/test/pm_request_test.py
+++ b/test/pm_request_test.py
@@ -19,7 +19,7 @@ class PmRequestTest(unittest.TestCase):
     def test_ok(self):
         (out, err, proc) = call_script(self.scriptpath,
                                        ['maven', 'junit:junit'],
-                                       extra_env=self.env, async=True)
+                                       extra_env=self.env, wait=False)
         conn, _ = self.sock.accept()
         request = conn.makefile().readline().rstrip()
         self.assertEqual(request, "install 'mvn(junit:junit)'")
@@ -31,7 +31,7 @@ class PmRequestTest(unittest.TestCase):
     def test_nok(self):
         (out, err, proc) = call_script(self.scriptpath,
                                        ['maven', 'junit:junit'],
-                                       extra_env=self.env, async=True)
+                                       extra_env=self.env, wait=False)
         conn, _ = self.sock.accept()
         request = conn.makefile().readline().rstrip()
         self.assertEqual(request, "install 'mvn(junit:junit)'")
@@ -43,7 +43,7 @@ class PmRequestTest(unittest.TestCase):
     def test_jar(self):
         (out, err, proc) = call_script(self.scriptpath,
                                        ['maven', 'gid:aid:jar::'],
-                                       extra_env=self.env, async=True)
+                                       extra_env=self.env, wait=False)
         conn, _ = self.sock.accept()
         request = conn.makefile().readline().rstrip()
         self.assertEqual(request, "install 'mvn(gid:aid)'")
@@ -55,7 +55,7 @@ class PmRequestTest(unittest.TestCase):
     def test_full_coords(self):
         (out, err, proc) = call_script(self.scriptpath,
                                        ['maven', 'gid:aid:ext:cla:ver'],
-                                       extra_env=self.env, async=True)
+                                       extra_env=self.env, wait=False)
         conn, _ = self.sock.accept()
         request = conn.makefile().readline().rstrip()
         self.assertEqual(request, "install 'mvn(gid:aid:ext:cla:ver)'")
@@ -67,7 +67,7 @@ class PmRequestTest(unittest.TestCase):
     def test_connection_error(self):
         (out, err, proc) = call_script(self.scriptpath,
                                        ['maven', 'junit:junit'],
-                                       extra_env=self.env, async=True)
+                                       extra_env=self.env, wait=False)
         conn, _ = self.sock.accept()
         conn.close()
         ret = proc.wait()

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -24,7 +24,7 @@ for var in ('PYTHONPATH', 'COVERAGE_PROCESS_START'):
         SCRIPT_ENV[var] = os.environ[var]
 
 
-def call_script(name, args, stdin=None, extra_env={}, async=False):
+def call_script(name, args, stdin=None, extra_env={}, wait=True):
     with open("tmpout", 'w') as outfile:
         with open("tmperr", 'w') as errfile:
             procargs = [sys.executable, name]
@@ -36,7 +36,7 @@ def call_script(name, args, stdin=None, extra_env={}, async=False):
                                     env=env,
                                     stdin=subprocess.PIPE,
                                     universal_newlines=True)
-            if async:
+            if not wait:
                 return (outfile, errfile, proc)
             proc.communicate(stdin)
             ret = proc.wait()


### PR DESCRIPTION
async is a reserved keyword in Python 3.7 and keeping it results
in syntax error. I didn't want to rename the argument to asynch or
async_ without thinking, so I've checked what it does and went with
wait. I reversed the logic because I didn't want it to be nowait.

Feel free to rename it differently, but please do.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1592988