### PR TITLE
Setting JAVA_HOME when using the java-1.8.0-openjdk (the JRE, without the devel package) doesn't work

### DIFF
--- a/java-utils/java-functions
+++ b/java-utils/java-functions
@@ -197,7 +197,7 @@ set_javacmd()
     set_jvm
 
     # Add all sorts of jvm layouts here
-    for cmd in jre/sh/java bin/java; do
+    for cmd in jre/sh/java jre/bin/java bin/java; do
 	JAVACMD="${JAVA_HOME}/${cmd}"
 	if [ -x "${JAVACMD}" ]; then
 	    _log "Using configured JAVACMD: $JAVACMD"


### PR DESCRIPTION
To reproduce, you must install tomcat and an openjdk JRE (prior to version 9, the path changed then). See steps below:

1) Install tomcat (which installs java-1.8.0-openjdk, by default), install java-1.7.0-openjdk so that you have a java install to switch to, and add java7 as the location for your JAVA_HOME variable:

```
# tail -n1 /etc/sysconfig/tomcat
JAVA_HOME="/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.201-2.6.16.1.el7_6.x86_64/"
```

2) Start tomcat and observe that it still uses the alternatives version:

```
# systemctl start tomcat
Java virtual machine used: /usr/lib/jvm/jre/bin/java
classpath used: /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
main class used: org.apache.catalina.startup.Bootstrap
flags used:  
options used: -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat -Djava.endorsed.dirs= -Djava.io.tmpdir=/var/cache/tomcat/temp -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
....
```

3) Install the java-1.7.0-openjdk-devel package (full JDK distribution):

*Note*: If you enable JAVAPACKAGES_DEBUG before sources the java-functions file in the tomcat/functions script, you can see which java bin is found:

Without the JDK (devel package) installed
```
# /usr/libexec/tomcat/server start
/usr/libexec/tomcat/server: Java config directories are:
/usr/libexec/tomcat/server:   * /etc/java
/usr/libexec/tomcat/server: Loading config file: /etc/java/java.conf
/usr/libexec/tomcat/server: Skipping config file /root/.java/java.conf: file does not exist
/usr/libexec/tomcat/server: ABRT Java connector is disabled
/usr/libexec/tomcat/server: Using configured JAVACMD: /usr/lib/jvm/jre/bin/java
Java virtual machine used: /usr/lib/jvm/jre/bin/java
```

With JDK installed
```
/usr/libexec/tomcat/server: Java config directories are:
/usr/libexec/tomcat/server:   * /etc/java
/usr/libexec/tomcat/server: Loading config file: /etc/java/java.conf
/usr/libexec/tomcat/server: Skipping config file /usr/share/tomcat/.java/java.conf: file does not exist
/usr/libexec/tomcat/server: ABRT Java connector is disabled
/usr/libexec/tomcat/server: Using configured JAVACMD: /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.201-2.6.16.1.el7_6.x86_64//bin/java
Java virtual machine used: /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.201-2.6.16.1.el7_6.x86_64//bin/java
```

The debug messages above are generated by the java-functions script's `set_javacmd()` function, see the following snippet:

```
....
    for cmd in jre/sh/java bin/java; do
    JAVACMD="${JAVA_HOME}/${cmd}"
    if [ -x "${JAVACMD}" ]; then
        _log "Using configured JAVACMD: $JAVACMD"
        ....
    JAVACMD=$(which java 2>/dev/null || :)
    if [ -x "${JAVACMD}" ]; then
    _log "Using JAVACMD from PATH: $JAVACMD"
    ....

    _err "Failed to set JAVACMD"
    return 1
```

Note from the logic above that if your JAVA_HOME directory does not contain `jre/sh/java` or `bin/java` it falls back to using the alternatives version (i.e. `which java` output). The java-1.7.0-openjdk and java-1.8.0-openjdk packages have the java binary located in `jre/bin/java`, not `jre/sh/java`, so the path should be added to the list of location checked.