### PR TITLE
Use XMvn Javadoc MOJO by default

### DIFF
--- a/java-utils/mvn_build.py
+++ b/java-utils/mvn_build.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
                       help="Enable Maven debugging output (implies -d).")
     parser.add_option("--xmvn-javadoc",
                       action="store_true",
-                      help="Use experimental XMvn javadoc MOJO to generate javadocs.")
+                      help="Use XMvn Javadoc MOJO to generate javadocs.")
 
     (options, args) = parser.parse_args()
     xc = XMvnConfig()

--- a/macros.d/macros.fjava
+++ b/macros.d/macros.fjava
@@ -131,7 +131,7 @@
 #
 # For summary of accepted options execute `mvn-build --help` command.
 #
-%mvn_build %{?scl:@{javadir}-utils/scl-enable %{?scl_maven} %{scl} -- }@{pyinterpreter} @{javadir}-utils/mvn_build.py %{?base_xmvn_opts} %{?xmvn_opts} %{?xmvn_bootstrap: -b} %{?_without_javadoc: -j $(> .mfiles-javadoc)}%{?_without_tests: -f}
+%mvn_build %{?scl:@{javadir}-utils/scl-enable %{?scl_maven} %{scl} -- }@{pyinterpreter} @{javadir}-utils/mvn_build.py --xmvn-javadoc %{?base_xmvn_opts} %{?xmvn_opts} %{?xmvn_bootstrap: -b} %{?_without_javadoc: -j $(> .mfiles-javadoc)}%{?_without_tests: -f}
 
 
 # %gradle_build - build Gradle project

--- a/test/data/mvn_build/singleton_out_rpm
+++ b/test/data/mvn_build/singleton_out_rpm
@@ -1,0 +1,1 @@
+--batch-mode --offline verify org.fedoraproject.xmvn:xmvn-mojo:install org.fedoraproject.xmvn:xmvn-mojo:javadoc org.fedoraproject.xmvn:xmvn-mojo:builddep

--- a/test/mvn_macros_test.py
+++ b/test/mvn_macros_test.py
@@ -275,7 +275,7 @@ class MvnMacrosTest(unittest.TestCase):
         with open(argspath, 'r') as argsfile:
             exp = '--batch-mode --offline ' + \
                   'verify org.fedoraproject.xmvn:xmvn-mojo:install ' + \
-                  'org.apache.maven.plugins:maven-javadoc-plugin:aggregate ' + \
+                  'org.fedoraproject.xmvn:xmvn-mojo:javadoc ' + \
                   'org.fedoraproject.xmvn:xmvn-mojo:builddep\n'
             self.assertEqual(argsfile.read(), exp)
 
@@ -296,7 +296,7 @@ class MvnMacrosTest(unittest.TestCase):
 
         expfile = os.path.join(pack.buildpath, '.xmvn', 'out')
         actfile = os.path.join(DIRPATH, 'data', 'mvn_build',
-                                   'singleton_out')
+                                   'singleton_out_rpm')
         with open(actfile, 'r') as act:
             with open(expfile, 'r') as exp:
                 self.assertEqual(act.read(), exp.read())
@@ -324,7 +324,7 @@ class MvnMacrosTest(unittest.TestCase):
         with open(argspath, 'r') as argsfile:
             exp = '--batch-mode --offline --log-file /var/log/xmvn ' + \
                   'verify org.fedoraproject.xmvn:xmvn-mojo:install ' + \
-                  'org.apache.maven.plugins:maven-javadoc-plugin:aggregate ' + \
+                  'org.fedoraproject.xmvn:xmvn-mojo:javadoc ' + \
                   'org.fedoraproject.xmvn:xmvn-mojo:builddep\n'
             self.assertEqual(argsfile.read(), exp)
 
@@ -339,7 +339,7 @@ class MvnMacrosTest(unittest.TestCase):
         with open(argspath, 'r') as argsfile:
             exp = '--batch-mode ' + \
                   'verify org.fedoraproject.xmvn:xmvn-mojo:install ' + \
-                  'org.apache.maven.plugins:maven-javadoc-plugin:aggregate ' + \
+                  'org.fedoraproject.xmvn:xmvn-mojo:javadoc ' + \
                   'org.fedoraproject.xmvn:xmvn-mojo:builddep\n'
             self.assertEqual(argsfile.read(), exp)
 
@@ -368,7 +368,7 @@ class MvnMacrosTest(unittest.TestCase):
         with open(argspath, 'r') as argsfile:
             exp = '--batch-mode --offline -Dmaven.test.skip=true ' + \
                   'package org.fedoraproject.xmvn:xmvn-mojo:install ' + \
-                  'org.apache.maven.plugins:maven-javadoc-plugin:aggregate ' + \
+                  'org.fedoraproject.xmvn:xmvn-mojo:javadoc ' + \
                   'org.fedoraproject.xmvn:xmvn-mojo:builddep\n'
             self.assertEqual(argsfile.read(), exp)
 


### PR DESCRIPTION
Fedora Java SIG [decided to switch to XMvn Javadoc MOJO](https://lists.fedoraproject.org/archives/list/java-devel@lists.fedoraproject.org/message/UD7Q5DYAWI7YO4VW7UZPDWR644V7S462/). This PR should allow Fedora to drop downstream patch.