### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,6 @@ script:
   - ./check
 after_success:
   - codecov -f coverage.xml
+arch:
+ - amd64
+ - ppc64le


### PR DESCRIPTION
Hi,
I had added ppc64le architecture support on travis-ci and looks like its been successfully added. I believe it is ready for the final review and merge.

The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/javapackages/builds/187200530
Please have a look.

Thanks!!
Kishor Kunal Raj