### PR TITLE
Integration with javapackages-bootstrap

### DIFF
--- a/configs/configuration.xml
+++ b/configs/configuration.xml
@@ -61,6 +61,7 @@
   <resolverSettings>
     <metadataRepositories>
       <repository>/usr/share/maven-metadata</repository>
+      <repository>/usr/share/javapackages-bootstrap/maven-metadata</repository>
     </metadataRepositories>
   </resolverSettings>
   <installerSettings>

--- a/depgenerators/fileattrs/javadoc.attr
+++ b/depgenerators/fileattrs/javadoc.attr
@@ -1,3 +1,3 @@
-%__javadoc_requires	%{_rpmconfigdir}/javadoc.req
-%__javadoc_requires_opts %{nil}
+%__javadoc_requires	%{_buildshell}
+%__javadoc_requires_opts -c '%{?jpb_env} %{_rpmconfigdir}/javadoc.req'
 %__javadoc_path	^%{_javadocdir}/.[^/]*$

--- a/depgenerators/fileattrs/maven.attr
+++ b/depgenerators/fileattrs/maven.attr
@@ -1,5 +1,5 @@
-%__maven_provides	%{_rpmconfigdir}/maven.prov
-%__maven_provides_opts	--cachedir %{_builddir}/%{?buildsubdir} --rpm-pid %{lua:print(math.floor(posix.getprocessid("pid")))}
-%__maven_requires	%{_rpmconfigdir}/maven.req
-%__maven_requires_opts	--cachedir %{_builddir}/%{?buildsubdir} --rpm-pid %{lua:print(math.floor(posix.getprocessid("pid")))}
+%__maven_provides	%{_buildshell}
+%__maven_provides_opts	-c '%{?jpb_env} %{_rpmconfigdir}/maven.prov --cachedir %{_builddir}/%{?buildsubdir} --rpm-pid %{lua:print(math.floor(posix.getprocessid("pid")))}'
+%__maven_requires	%{_buildshell}
+%__maven_requires_opts	-c '%{?jpb_env} %{_rpmconfigdir}/maven.req --cachedir %{_builddir}/%{?buildsubdir} --rpm-pid %{lua:print(math.floor(posix.getprocessid("pid")))}'
 %__maven_path	^%{_datadir}/maven-metadata/.*

--- a/depgenerators/fileattrs/osgi.attr
+++ b/depgenerators/fileattrs/osgi.attr
@@ -1,5 +1,5 @@
-%__osgi_provides	%{_rpmconfigdir}/osgi.prov
-%__osgi_provides_opts	--cachedir %{_builddir}/%{?buildsubdir} --rpm-pid %{lua:print(math.floor(posix.getprocessid("pid")))}
-%__osgi_requires	%{_rpmconfigdir}/osgi.req
-%__osgi_requires_opts	--cachedir %{_builddir}/%{?buildsubdir} --rpm-pid %{lua:print(math.floor(posix.getprocessid("pid")))}
+%__osgi_provides	%{_buildshell}
+%__osgi_provides_opts	-c '%{?jpb_env} %{_rpmconfigdir}/osgi.prov --cachedir %{_builddir}/%{?buildsubdir} --rpm-pid %{lua:print(math.floor(posix.getprocessid("pid")))}'
+%__osgi_requires	%{_buildshell}
+%__osgi_requires_opts	-c '%{?jpb_env} %{_rpmconfigdir}/osgi.req --cachedir %{_builddir}/%{?buildsubdir} --rpm-pid %{lua:print(math.floor(posix.getprocessid("pid")))}'
 %__osgi_path	^(.*\\.jar|((%{_prefix}/lib(64)?|%{_datadir})/.*/META-INF/MANIFEST.MF))$

--- a/macros.d/macros.fjava
+++ b/macros.d/macros.fjava
@@ -131,7 +131,7 @@
 #
 # For summary of accepted options execute `mvn-build --help` command.
 #
-%mvn_build @{pyinterpreter} @{javadir}-utils/mvn_build.py --xmvn-javadoc %{?base_xmvn_opts} %{?xmvn_opts} %{?xmvn_bootstrap: -b} %{?_without_javadoc: -j $(> .mfiles-javadoc)}%{?_without_tests: -f}
+%mvn_build %{?jpb_env} @{pyinterpreter} @{javadir}-utils/mvn_build.py --xmvn-javadoc %{?base_xmvn_opts} %{?xmvn_opts} %{?xmvn_bootstrap: -b} %{?_without_javadoc: -j $(> .mfiles-javadoc)}%{?_without_tests: -f}
 
 
 # %gradle_build - build Gradle project
@@ -143,7 +143,7 @@
 #
 # For summary of accepted options execute `mvn-build --help` command.
 #
-%gradle_build @{pyinterpreter} @{javadir}-utils/mvn_build.py --gradle %{?base_xmvn_opts} %{?xmvn_opts} %{?xmvn_bootstrap: -b} %{?_without_javadoc: -j $(> .mfiles-javadoc)}%{?_without_tests: -f}
+%gradle_build %{?jpb_env} @{pyinterpreter} @{javadir}-utils/mvn_build.py --gradle %{?base_xmvn_opts} %{?xmvn_opts} %{?xmvn_bootstrap: -b} %{?_without_javadoc: -j $(> .mfiles-javadoc)}%{?_without_tests: -f}
 
 
 # %mvn_install - install Maven project
@@ -153,7 +153,7 @@
 # This macro causes previously built Maven project to be installed into
 # buildroot. It is intended to be placed in %install section of spec file.
 #
-%mvn_install(J:X) xmvn-install %{?base_xmvn_opts} %{?xmvn_install_opts} %{?-X} -R .xmvn-reactor -n %{name} %{?xmvn_install_repo:-i %{xmvn_install_repo}} -d "%{buildroot}" \
+%mvn_install(J:X) %{?jpb_env} xmvn-install %{?base_xmvn_opts} %{?xmvn_install_opts} %{?-X} -R .xmvn-reactor -n %{name} %{?xmvn_install_repo:-i %{xmvn_install_repo}} -d "%{buildroot}" \
 %{-J*:jdir="%{-J*}"}%{!-J*:jdir=target/site/apidocs; [ -d .xmvn/apidocs ] && jdir=.xmvn/apidocs} \
 %{__mkdir_p} %{buildroot}%{_licensedir} \
 if [ -d "${jdir}" ]; then \
@@ -170,7 +170,7 @@ fi \
 #
 # Substitutes Java archives in given directory with symlinks to system-wide or
 # just installed versions.
-%mvn_subst xmvn-subst %{?base_xmvn_opts} %{?xmvn_subst_opts} -R %{buildroot}
+%mvn_subst %{?jpb_env} xmvn-subst %{?base_xmvn_opts} %{?xmvn_subst_opts} -R %{buildroot}
 
 
 #==============================================================================

--- a/macros.d/macros.jpackage
+++ b/macros.d/macros.jpackage
@@ -15,7 +15,7 @@
 #==============================================================================
 # ---- default Java commands
 
-%ant            JAVA_HOME=%{java_home} ant
+%ant            %{?jpb_env} JAVA_HOME=%{java_home} ant
 %jar            %{java_home}/bin/jar
 %java           %(. @{javadir}-utils/java-functions; set_javacmd; echo $JAVACMD)
 %javac          %{java_home}/bin/javac


### PR DESCRIPTION
When [javapackages-bootstrap](/fedora-java/javapackages-bootstrap) is installed then javapackages should use it instead of regular dependencies.