### PR TITLE
Make maven_depmap order of aliases reproducible

### DIFF
--- a/java-utils/maven_depmap.py
+++ b/java-utils/maven_depmap.py
@@ -213,7 +213,7 @@ def add_aliases(artifact, additions):
 
     aliases = additions.split(',')
     result = list()
-    for a in aliases:
+    for a in sorted(aliases):
         alias = MetadataAlias.from_mvn_str(a)
         alias.extension = artifact.extension
         result.append(alias)

--- a/java-utils/mvn_artifact.py
+++ b/java-utils/mvn_artifact.py
@@ -167,7 +167,7 @@ def gather_dependencies(pom_path):
     parent = pom.parent
     while parent:
         ppom = None
-        if parent.relativePath:
+        if hasattr(parent, 'relativePath') and parent.relativePath:
             try:
                 ppom_path = os.path.join(os.path.dirname(curr_pom._path),
                                          parent.relativePath)


### PR DESCRIPTION
Make the order of aliases reproducible if registered using the maven_depmap.py