### PR TITLE
Fix incompatibility with RPM 4.20

### DIFF
--- a/test/mvn_macros_test.py
+++ b/test/mvn_macros_test.py
@@ -379,7 +379,7 @@ class MvnMacrosTest(unittest.TestCase):
         _, stderr, return_value = pack.run_install()
         self.assertEqual(return_value, 0, stderr)
 
-        argspath = os.path.join('rpmbuild', 'BUILD', '.xmvn', 'install-out')
+        argspath = os.path.join(pack.buildpath, '.xmvn', 'install-out')
         with open(argspath, 'r') as argsfile:
             args = argsfile.read()
             self.assertTrue(re.match(r'-R \.xmvn-reactor -n \S+ -d \S+\n',
@@ -392,7 +392,7 @@ class MvnMacrosTest(unittest.TestCase):
         _, stderr, return_value = pack.run_install()
         self.assertEqual(return_value, 0, stderr)
 
-        argspath = os.path.join('rpmbuild', 'BUILD', '.xmvn', 'install-out')
+        argspath = os.path.join(pack.buildpath, '.xmvn', 'install-out')
         with open(argspath, 'r') as argsfile:
             args = argsfile.read()
             self.assertTrue(re.match(r'-X -R \.xmvn-reactor -n \S+ -d \S+\n',
@@ -400,21 +400,21 @@ class MvnMacrosTest(unittest.TestCase):
 
     @rpm_test()
     def test_mvn_install_directory(self, pack):
-        pack.append_to_build('mkdir ../doc')
-        pack.append_to_build('touch ../doc/file')
+        pack.append_to_build('mkdir doc')
+        pack.append_to_build('touch doc/file')
         pack.append_to_install('%mvn_install -J doc')
         pack.append_to_install('%files -f .mfiles-javadoc')
 
         _, stderr, return_value = pack.run_install()
         self.assertEqual(return_value, 0, stderr)
 
-        argspath = os.path.join('rpmbuild', 'BUILD', '.xmvn', 'install-out')
+        argspath = os.path.join(pack.buildpath, '.xmvn', 'install-out')
         with open(argspath, 'r') as argsfile:
             args = argsfile.read()
             self.assertTrue(re.match(r'-R \.xmvn-reactor -n \S+ -d \S+\n',
                                      args), args)
 
-        mfilespath = os.path.join('rpmbuild', 'BUILD', '.mfiles-javadoc')
+        mfilespath = os.path.join(pack.buildpath, '.mfiles-javadoc')
         with open(mfilespath, 'r') as mfiles:
             self.assertEqual(mfiles.read(),
                              '/usr/share/javadoc/test_mvn_install_directory\n')

--- a/test/pom_macros_test.py
+++ b/test/pom_macros_test.py
@@ -22,10 +22,10 @@ def exec_macro(command = "", pom = "pom.xml", tail=''):
             pomname = os.path.basename(pom)
             package = Package(function.__name__)
             package.add_source(pompath)
-            pomsourcepath = os.path.join(package.buildpath, pomname)
             package.append_to_prep('%{command} {pom} {tail}'.format(command=command,
                 pom=pomname, tail=tail))
             stdin, stderr, return_value = package.run_prep()
+            pomsourcepath = os.path.join(package.buildpath, pomname)
 
             function(self, stdin, stderr, return_value, pomsourcepath)
         return test_decorated

--- a/test/test_rpmbuild.py
+++ b/test/test_rpmbuild.py
@@ -21,8 +21,7 @@ class Package(object):
     """
     def __init__(self, name):
         self.__name = name
-        self.__macros = [u'%topdir {cwd}/rpmbuild'.format(cwd=os.getcwd()),
-                         u'%_buildhost testhost']
+        self.__macros = [u'%_buildhost testhost']
         self.__sources = []
         self.__begin = ''
         self.__prep = ''


### PR DESCRIPTION
RPM 4.20 creates a different BUILD directory structure than RPM 4.19 and earlier.
    
To avoid reliance on any particular BUILD directory strucure, create build subdir with %setup and then search BUILD directory to find the actual location of build subdir.