### PR TITLE
Fix the use of java-functions in scripts

### DIFF
--- a/bin/build-classpath
+++ b/bin/build-classpath
@@ -21,12 +21,6 @@ exit 2
 
 [ "$#" -eq "0" ] && usage
 
-set_javacmd || exit 3
-
-check_java_env || exit 4
-
-set_jvm_dirs || exit 5
-
 _ALLFOUND="true"
 
 for extension in "$@" ; do

--- a/bin/build-jar-repository
+++ b/bin/build-jar-repository
@@ -36,12 +36,6 @@ exit 2
 
 [ "$#" -lt "2" ] && usage
 
-set_javacmd || exit 3
-
-check_java_env || exit 4
-
-set_jvm_dirs || exit 5
-
 _ALLFOUND="true"
 
 link_jar_repository $@

--- a/bin/check-binary-files
+++ b/bin/check-binary-files
@@ -5,10 +5,6 @@
 # JPackage Project <http://www.jpackage.org/>
 #
 
-# Import java functions
-[ -r "@{javadir}-utils/java-functions" ] \
- &&  . "@{javadir}-utils/java-functions" || exit 1
-
 # Prints help message
 usage() {
 	cat >&2 << EOF_USAGE
@@ -26,10 +22,6 @@ EOF_USAGE
 [ "$1" = "--help" ] && usage
 
 [ "$#" = 0 ] && usage
-
-set_javacmd || exit 3
-check_java_env || exit 4
-set_jvm_dirs || exit 5
 
 # Directory in which script was invoked
 _WORKING_DIR=`pwd`

--- a/bin/clean-binary-files
+++ b/bin/clean-binary-files
@@ -5,10 +5,6 @@
 # JPackage Project <http://www.jpackage.org/>
 #
 
-# Import java functions
-[ -r "@{javadir}-utils/java-functions" ] \
- &&  . "@{javadir}-utils/java-functions" || exit 1
-
 # Prints help message
 usage() {
 	cat >&2 << EOF_USAGE
@@ -34,10 +30,6 @@ EOF_USAGE
 [ "$1" = "--help" ] && usage
 
 [ "$#" = 0 ] && usage
-
-set_javacmd || exit 3
-check_java_env || exit 4
-set_jvm_dirs || exit 5
 
 # Directory in which script was invoked
 _WORKING_DIR=`pwd`

--- a/bin/create-jar-links
+++ b/bin/create-jar-links
@@ -5,10 +5,6 @@
 # JPackage Project <http://www.jpackage.org/>
 #
 
-# Import java functions
-[ -r "@{javadir}-utils/java-functions" ] \
- &&  . "@{javadir}-utils/java-functions" || exit 1
-
 # Prints help message
 usage() {
 	cat >&2 << EOF_USAGE
@@ -27,10 +23,6 @@ EOF_USAGE
 [ "$1" = "--help" ] && usage
 
 [ "$#" = 0 ] && usage
-
-set_javacmd || exit 3
-check_java_env || exit 4
-set_jvm_dirs || exit 5
 
 # Default jar map
 _JAR_MAP_FILE="@{javadir}-utils/jarname-jpp-map"

--- a/bin/diff-jars
+++ b/bin/diff-jars
@@ -12,14 +12,6 @@
 #      - use mktemp(1) for creating temp files
 # 1.3  - fix java-functions location
 
-# Source functions library
-if [ -r "@{javadir}-utils/java-functions" ] ; then
-  . "@{javadir}-utils/java-functions"
-else
-  echo "Can't find functions library, aborting"
-  exit 1
-fi
-
 # Check arguments
 if [ $# != 2 ] ; then
 	echo  "usage: `basename $0` jar1 jar2"
@@ -43,8 +35,7 @@ else
 fi
 
 # Get jar command
-set_jvm
-JAR=$JAVA_HOME/bin/jar
+JAR=jar
 
 LIST1=`mktemp "$LIST1"`
 LIST2=`mktemp "$LIST2"`

--- a/bin/find-jar
+++ b/bin/find-jar
@@ -20,12 +20,6 @@ exit 2
 
 [ "$#" -ne "1" ] && usage
 
-set_javacmd || exit 3
-
-check_java_env || exit 4
-
-set_jvm_dirs || exit 5
-
 find_jar $1
 
 if [ $? != 0 ]; then

--- a/bin/rebuild-jar-repository
+++ b/bin/rebuild-jar-repository
@@ -52,12 +52,6 @@ done
 
 args="$args $@"
 
-set_javacmd || exit 3
-
-check_java_env || exit 4
-
-set_jvm_dirs || exit 5
-
 extension_list=$(find $repository -name '\[*\]*.jar' -not -type d | \
 sed 's+\]\[+/+g' | sed 's+.*\[++g' | sed 's+\].*++g' | sed 's+@+:+g' | sort | uniq)
 


### PR DESCRIPTION
Most of the scripts don't actually require Java and don't need to set up JVM, JAVA_HOME etc.

The `diff-jars` script that calls the `jar` utility can find it via PATH and doesn't necessairly need to set up JAVA_HOME either.