### PR TITLE
Drop default JRE/JDK

### DIFF
--- a/build
+++ b/build
@@ -76,6 +76,10 @@ expand depgenerators/fileattrs/osgi.attr
 expand depgenerators/fileattrs/maven.attr
 expand depgenerators/fileattrs/javadoc.attr
 
+while IFS== read -d' ' id path; do
+    echo "%java_home ${path}" >target/macros.fjava-"${id}"
+done <<<"${jvms}"
+
 manpage abs2rel
 manpage find-jar
 manpage gradle_build

--- a/configure
+++ b/configure
@@ -46,9 +46,6 @@ rpmmacrodir
 
 m2home
 
-default_jdk
-default_jre
-
 javaconfdir
 javadir
 javadocdir
@@ -72,6 +69,9 @@ vars_re=$(echo $vars | sed 's/ /\\|/g')
 eval $(for _; do echo "$_"; done |
     sed -n 's/^--\('"$vars_re"'\)=\(.*\)$/\1="\2"/;T;p')
 
+eval $(for _; do echo "$_"; done |
+    sed -n 's/^--jvm=\([^=]*\)=\(.*\)$/jvms="${jvms}\1=\2 "/;T;p')
+
 test -z "${prefix}" && prefix="/usr/local"
 test -z "${bindir}" && bindir="${prefix}/bin"
 test -z "${datadir}" && datadir="${prefix}/share"
@@ -89,7 +89,5 @@ test -z "${abrtlibdir}" && abrtlibdir="${prefix}/lib/abrt-java-connector"
 
 eval $(sed -n 's/^%_\('"$vars_re"'\)\ *\(.*\)$/\1="\2"/;T;s/%{_\(.*}\)/${\1/;p' macros.d/macros.javapackages-filesystem)
 
-test -z "${default_jdk}" && default_jdk="${jvmdir}/java"
-test -z "${default_jre}" && default_jre="${jvmdir}/jre"
-
 set | sed -n 's/^\('"$vars_re"'\)=/&/;T;p' >config.status
+echo "jvms=\"${jvms}\"" >>config.status

--- a/expand.sh
+++ b/expand.sh
@@ -51,7 +51,5 @@ expand()
         -e "s|@{sysconfdir}|${sysconfdir}|g" \
         -e "s|@{pyinterpreter}|${pyinterpreter}|g" \
         -e "s|@{abrtlibdir}|${abrtlibdir}|g" \
-        -e "s|@{default_jdk}|${default_jdk}|g" \
-        -e "s|@{default_jre}|${default_jre}|g" \
         "${1}" >"${target}"
 }

--- a/install
+++ b/install
@@ -137,6 +137,13 @@ inst_data target/find-jar.1 "${mandir}/man1"
 
 inst_data configs/configuration.xml "${m2home}"
 
+
+while IFS== read -d' ' id path; do
+    exec >files-local-"${id}"
+    inst_data target/macros.fjava-"${id}" "${rpmmacrodir}"
+done <<<"${jvms}"
+
+
 if [ -z "$pyinterpreter" ]; then
     exit 0
 fi

--- a/java-utils/java-functions
+++ b/java-utils/java-functions
@@ -134,22 +134,6 @@ _set_java_home()
         return
     fi
 
-    case "${_prefer_jre}" in
-        1|[Yy][Ee][Ss]|[Tt][Rr][Uu][Ee])
-            dirs="@{default_jre}:@{default_jdk}"
-            ;;
-        *)
-            dirs="@{default_jdk}:@{default_jre}"
-            ;;
-    esac
-
-    for JAVA_HOME in $dirs; do
-        if [ -d "${JAVA_HOME}" ]; then
-            _log "Using configured JAVA_HOME: ${JAVA_HOME}"
-            return
-        fi
-    done
-
     unset JAVA_HOME
 }
 

--- a/javapackages-tools.spec
+++ b/javapackages-tools.spec
@@ -9,9 +9,6 @@
 %global python_prefix python3
 %global python_interpreter %{?__python3}%{!?__python3:dummy}
 
-%global default_jdk %{_prefix}/lib/jvm/java-21-openjdk
-%global default_jre %{_prefix}/lib/jvm/jre-21-openjdk
-
 %global maven_home %{_usr}/share/xmvn
 
 Name:           javapackages-tools
@@ -40,8 +37,6 @@ Requires:       javapackages-filesystem = %{version}-%{release}
 Requires:       coreutils
 Requires:       findutils
 Requires:       which
-# default JRE
-Requires:       java-21-openjdk-headless
 
 Provides:       jpackage-utils = %{version}-%{release}
 
@@ -56,10 +51,13 @@ Provides:       eclipse-filesystem = %{version}-%{release}
 This package provides some basic directories into which Java packages
 install their content.
 
-%package -n maven-local
+%package -n maven-local-openjdk21
 Summary:        Macros and scripts for Maven packaging support
+RemovePathPostfixes: -openjdk21
+Requires:       java-21-openjdk-devel
+Provides:       maven-local = %{version}-%{release}
 Requires:       %{name} = %{version}-%{release}
-Requires:       javapackages-local = %{version}-%{release}
+Requires:       javapackages-local-openjdk21 = %{version}-%{release}
 Requires:       xmvn-minimal
 Requires:       mvn(org.fedoraproject.xmvn:xmvn-mojo)
 # Common Maven plugins required by almost every build. It wouldn't make
@@ -69,11 +67,12 @@ Requires:       mvn(org.apache.maven.plugins:maven-jar-plugin)
 Requires:       mvn(org.apache.maven.plugins:maven-resources-plugin)
 Requires:       mvn(org.apache.maven.plugins:maven-surefire-plugin)
 # Remove in Fedora 45
+Obsoletes:      maven-local < 7
 Obsoletes:      maven-local-openjdk8 < 6.2.0-29
 Obsoletes:      maven-local-openjdk11 < 6.2.0-29
 Obsoletes:      maven-local-openjdk17 < 6.2.0-29
 
-%description -n maven-local
+%description -n maven-local-openjdk21
 This package provides macros and scripts to support packaging Maven artifacts.
 
 %if %{with ivy}
@@ -97,17 +96,19 @@ Requires:       %{python_prefix}-lxml
 Module for handling, querying and manipulating of various files for Java
 packaging in Linux distributions
 
-%package -n javapackages-local
+%package -n javapackages-local-openjdk21
 Summary:        Non-essential macros and scripts for Java packaging support
+Obsoletes:      javapackages-local < 7
+Provides:       javapackages-local = %{version}-%{release}
 Requires:       javapackages-common = %{version}-%{release}
+Requires:       xmvn-tools
 # Java build systems don't have hard requirement on java-devel, so it should be there
 Requires:       java-21-openjdk-devel
-Requires:       xmvn-tools
 %if %{with xmvn_generator}
 Requires:       xmvn-generator
 %endif
 
-%description -n javapackages-local
+%description -n javapackages-local-openjdk21
 This package provides non-essential macros and scripts to support Java packaging.
 
 %package -n javapackages-generators
@@ -135,23 +136,14 @@ Requires:       javapackages-local = %{version}-%{release}
 This package provides previously deprecated macros and scripts to
 support Java packaging as well as some additions to them.
 
-%package -n maven-local-openjdk21
-Summary:        OpenJDK 21 toolchain for XMvn
-RemovePathPostfixes: -openjdk21
-Requires:       maven-local
-Requires:       java-21-openjdk-devel
-
-%description -n maven-local-openjdk21
-OpenJDK 21 toolchain for XMvn
-
 %prep
 %autosetup -p1 -C
 
 %build
 %configure --pyinterpreter=%{python_interpreter} \
-    --default_jdk=%{default_jdk} --default_jre=%{default_jre} \
     --rpmmacrodir=%{_rpmmacrodir} --rpmconfigdir=%{_rpmconfigdir} \
-    --m2home=%{maven_home}
+    --m2home=%{maven_home} \
+    --jvm=openjdk21=%{_jvmdir}/jre-21-openjdk
 ./build
 
 %install
@@ -206,17 +198,15 @@ ln -s %{_datadir}/java-utils %{buildroot}%{_usr}/share/java-utils
 
 %files -n javapackages-compat -f files-compat
 
-%files -n javapackages-local
-
-%files -n maven-local
-
-%if %{with ivy}
-%files -n ivy-local -f files-ivy
-%endif
+%files -n javapackages-local-openjdk21 -f files-local-openjdk21
 
 %files -n maven-local-openjdk21
 %dir %{maven_home}/conf
 %{maven_home}/conf/toolchains.xml-openjdk21
+
+%if %{with ivy}
+%files -n ivy-local -f files-ivy
+%endif
 
 %files -n %{python_prefix}-javapackages -f files-python
 %license LICENSE

--- a/macros.d/macros.jpackage
+++ b/macros.d/macros.jpackage
@@ -7,11 +7,6 @@
 #   Nicolas Mailhot <Nicolas.Mailhot@laPoste.net>
 #
 
-#
-# Current default JVM home.
-#
-%java_home      %(. @{javadir}-utils/java-functions; set_jvm; echo $JAVA_HOME)
-
 #==============================================================================
 # ---- default Java commands
 
@@ -32,7 +27,6 @@
 # %3    options
 # %4    jars (separated by ':')
 # %5    the name of script you wish to create
-# %6    whether to prefer a jre over a sdk when finding a jvm
 #
 %jpackage_script() \
 install -d -m 755 %{buildroot}%{_bindir} \
@@ -42,8 +36,10 @@ cat > %{buildroot}%{_bindir}/%5 << EOF \
 # %{name} script\
 # JPackage Project <http://www.jpackage.org/>\
 \
+# Set default JAVA_HOME\
+export JAVA_HOME="\\${JAVA_HOME:-%{?java_home}}"\
+\
 # Source functions library\
-_prefer_jre="%{?6}"\
 . @{javadir}-utils/java-functions\
 \
 # Source system prefs\


### PR DESCRIPTION
Remove the notion of default system JRE/JDK.
Base Javapackages should be agnostic about Java version being used.
Don't require or assume any particular JDK/JRE packages.

For every JVM passed to the configure script, a separate subpackage is created that configures `%java_home` et al.
Only these specific subpackages can make assumptions about Java version being used.