### PR TITLE
Fix tests with python 3.4

### DIFF
--- a/bin/abs2rel
+++ b/bin/abs2rel
@@ -36,4 +36,4 @@ if [ $# -ne 2 ]; then
     exit 1
 fi
 
-exec realpath -s --relative-to="$2" "$1"
+exec realpath -m -s --relative-to="$2" "$1"

--- a/test/test_rpmbuild.py
+++ b/test/test_rpmbuild.py
@@ -4,7 +4,6 @@ import re
 import sys
 import subprocess
 import shutil
-import glob
 
 from textwrap import dedent
 
@@ -101,8 +100,9 @@ class Package(object):
         os.remove('tmperr')
         # RPM 4.19 and 4.20 use different BUILD directory structure, thus we search the filesystem
         # to find the actual location of build subdir without reliance on particular structure
-        self.buildpath = glob.glob('rpmbuild/BUILD/**/{name}-subdir'.format(name=self.__name),
-                                   recursive=True)[0]
+        self.buildpath = [os.path.join(dirpath, d)
+            for dirpath, dirnames, files in os.walk('rpmbuild/BUILD')
+            for d in dirnames if d.endswith('{name}-subdir'.format(name=self.__name))][0]
         return (out, err, ret)
 
     def set_env(self, name, value):


### PR DESCRIPTION
The glob.glob does not have field "recursive" in python 3.4. The following is using the os.walk to do the same thing and retains python 3.4 compatibility.