### PR TITLE
Double-quote to avoid substitution during build

### DIFF
--- a/macros.d/macros.jpackage
+++ b/macros.d/macros.jpackage
@@ -37,7 +37,7 @@ cat > %{buildroot}%{_bindir}/%5 << EOF \
 # JPackage Project <http://www.jpackage.org/>\
 \
 # Set default JAVA_HOME\
-export JAVA_HOME="\\${JAVA_HOME:-%{?java_home}}"\
+export JAVA_HOME="\\${JAVA_HOME:-%%{?java_home}}"\
 \
 # Source functions library\
 . @{javadir}-utils/java-functions\


### PR DESCRIPTION
A little tiny fix for a typo that prevents the generated scripts to work when JAVA_HOME is not set