### PR TITLE
Further improve java-functions to work without JAVA_HOME

### DIFF
--- a/java-utils/java-functions
+++ b/java-utils/java-functions
@@ -124,7 +124,7 @@ _load_java_conf()
 }
 
 
-# Set the java virtual machine
+# Obsolete, does nothing
 set_jvm()
 {
     return 0
@@ -151,8 +151,6 @@ set_javacmd()
     if [ -x "${JAVACMD}" ]; then
 	return
     fi
-
-    set_jvm
 
     # Add all sorts of jvm layouts here
     for cmd in jre/sh/java jre/bin/java bin/java; do
@@ -225,7 +223,7 @@ run()
     eval "exec \"\${JAVACMD}\" ${FLAGS} -classpath \"\${CLASSPATH}\" ${OPTIONS} \"\${MAIN_CLASS}\" \"\${@}\""
 }
 
-# Set JVM-related directories
+# Obsolete, does nothing
 set_jvm_dirs()
 {
     return 0

--- a/java-utils/java-functions
+++ b/java-utils/java-functions
@@ -376,12 +376,6 @@ find_jar()
 ## Checks java environment
 check_java_env()
 {
-    # This is usually set by set_jvm
-    if [ -z "${JAVA_HOME}" ]; then
-	_err "JAVA_HOME must be set"
-	return 1
-    fi
-
     if [ -z "${JAVACMD}" ]; then
 	_err "JAVACMD must be set"
 	return 2

--- a/java-utils/java-functions
+++ b/java-utils/java-functions
@@ -124,28 +124,16 @@ _load_java_conf()
 }
 
 
-# Test default JRE/JVM roots if nothing is defined yet
-_set_java_home()
-{
-    if [ -n "${JAVA_HOME}" ]; then
-        return
-    fi
-
-    unset JAVA_HOME
-}
-
 # Set the java virtual machine
 set_jvm()
 {
-    _set_java_home
+    return 0
 }
 
 # Set the classpath
 set_classpath()
 {
     local IFS
-
-    _set_java_home
 
     # get local classpath first
     set -- "${@}" ${ADDITIONAL_JARS}
@@ -240,8 +228,6 @@ run()
 # Set JVM-related directories
 set_jvm_dirs()
 {
-    _set_java_home
-
     return 0
 }
 

--- a/macros.d/macros.jpackage
+++ b/macros.d/macros.jpackage
@@ -59,7 +59,6 @@ BASE_OPTIONS=%3\
 BASE_JARS="%(echo %4 | sed -e 's,:, ,g')"\
 \
 # Set parameters\
-set_jvm\
 set_classpath \\$BASE_JARS\
 set_flags \\$BASE_FLAGS\
 set_options \\$BASE_OPTIONS\


### PR DESCRIPTION
- Remove JAVA_HOME check from check_java_env function - follow up on #119 
- Obsolete public functions `set_jvm` and `set_jvm_dirs` - they do nothing
- Remove private function `_set_java_home`

CC @fridrich 