### PR TITLE
Remove reference to %{java_home} from commands

### DIFF
--- a/macros.d/macros.jpackage
+++ b/macros.d/macros.jpackage
@@ -10,11 +10,11 @@
 #==============================================================================
 # ---- default Java commands
 
-%ant            %{?jpb_env} JAVA_HOME=%{java_home} ant
-%jar            %{java_home}/bin/jar
+%ant            %{?jpb_env} ant
+%jar            jar
 %java           %(. @{javadir}-utils/java-functions; set_javacmd; echo $JAVACMD)
-%javac          %{java_home}/bin/javac
-%javadoc        %{java_home}/bin/javadoc
+%javac          javac
+%javadoc        javadoc
 
 
 #

--- a/macros.d/macros.jpackage
+++ b/macros.d/macros.jpackage
@@ -35,10 +35,10 @@ cat > %{buildroot}%{_bindir}/%5 << EOF \
 #\
 # %{name} script\
 # JPackage Project <http://www.jpackage.org/>\
-\
+%{?java_home:\
 # Set default JAVA_HOME\
-export JAVA_HOME="\\${JAVA_HOME:-%{?java_home}}"\
-\
+export JAVA_HOME="\\${JAVA_HOME:-%{java_home}}"\
+}\
 # Source functions library\
 . @{javadir}-utils/java-functions\
 \


### PR DESCRIPTION
The %ant, %jar %javadoc %javac commands make little sense but they might be in spec files around the place. Make them just straight ant, jar, javadoc and javac as a stop-gap solution. Would be nice to echo before that they are deprecated, but that would be a lot of noise in the rpm build.