### PR TITLE
Don't export JAVA_HOME

### DIFF
--- a/macros.d/macros.jpackage
+++ b/macros.d/macros.jpackage
@@ -35,9 +35,9 @@ cat > %{buildroot}%{_bindir}/%5 << EOF \
 #\
 # %{name} script\
 # JPackage Project <http://www.jpackage.org/>\
-%{?java_home:\
-# Set default JAVA_HOME\
-export JAVA_HOME="\\${JAVA_HOME:-%{java_home}}"\
+%{?java_home:
+# Set default JAVA_HOME
+export JAVA_HOME="\\${JAVA_HOME:-%{java_home}}"
 }\
 # Source functions library\
 . @{javadir}-utils/java-functions\

--- a/macros.d/macros.jpackage
+++ b/macros.d/macros.jpackage
@@ -37,7 +37,7 @@ cat > %{buildroot}%{_bindir}/%5 << EOF \
 # JPackage Project <http://www.jpackage.org/>\
 %{?java_home:
 # Set default JAVA_HOME
-export JAVA_HOME="\\${JAVA_HOME:-%{java_home}}"
+JAVA_HOME="\\${JAVA_HOME:-%{java_home}}"
 }\
 # Source functions library\
 . @{javadir}-utils/java-functions\


### PR DESCRIPTION
Traditionally JAVA_HOME was not exported by launcher scripts.
Users have to export it explicitly if needed.