### PR TITLE
Revert "jpackage_script: Remove unneeded backslashes"

### DIFF
--- a/macros.d/macros.jpackage
+++ b/macros.d/macros.jpackage
@@ -35,9 +35,9 @@ cat > %{buildroot}%{_bindir}/%5 << EOF \
 #\
 # %{name} script\
 # JPackage Project <http://www.jpackage.org/>\
-%{?java_home:
-# Set default JAVA_HOME
-JAVA_HOME="\\${JAVA_HOME:-%{java_home}}"
+%{?java_home:\
+# Set default JAVA_HOME\
+JAVA_HOME="\\${JAVA_HOME:-%{java_home}}"\
 }\
 # Source functions library\
 . @{javadir}-utils/java-functions\


### PR DESCRIPTION
This is broken with rpm 4.14.1 for instance

This reverts commit 098485a23336cf7df692631d7bbb90db200d554d.