### PR TITLE
Initial implementation of %jp_binding macro

### DIFF
--- a/build
+++ b/build
@@ -76,8 +76,12 @@ expand depgenerators/fileattrs/osgi.attr
 expand depgenerators/fileattrs/maven.attr
 expand depgenerators/fileattrs/javadoc.attr
 
-while IFS== read -d' ' id path; do
-    echo "%java_home ${path}" >target/macros.fjava-"${id}"
+while IFS== read -d' ' java_id java_home; do
+    expand macros.d/macros.javapackages-binding target/macros.java-"${java_id}"
+    sed -i \
+	-e "s|@{java_id}|${java_id}|g" \
+	-e "s|@{java_home}|${java_home}|g" \
+	target/macros.java-"${java_id}"
 done <<<"${jvms}"
 
 manpage abs2rel

--- a/build
+++ b/build
@@ -67,6 +67,7 @@ expand macros.d/macros.jpackage
 expand macros.d/macros.fjava
 expand macros.d/macros.javapackages-compat
 expand java-utils/java-functions
+expand java-utils/jp_binding.sh
 expand depgenerators/maven.req
 expand depgenerators/maven.prov
 expand depgenerators/osgi.req

--- a/configure
+++ b/configure
@@ -60,6 +60,7 @@ jvmprivdir
 jvmsysconfdir
 mavenpomdir
 ivyxmldir
+jpbindingdir
 pyinterpreter
 abrtlibdir
 "

--- a/expand.sh
+++ b/expand.sh
@@ -45,6 +45,7 @@ expand()
         -e "s|@{javadir}|${javadir}|g" \
         -e "s|@{jnidir}|${jnidir}|g" \
         -e "s|@{jvmdir}|${jvmdir}|g" \
+        -e "s|@{jpbindingdir}|${jpbindingdir}|g" \
         -e "s|@{m2home}|${m2home}|g" \
         -e "s|@{prefix}|${prefix}|g" \
         -e "s|@{rundir}|${rundir}|g" \

--- a/install
+++ b/install
@@ -138,9 +138,9 @@ inst_data target/find-jar.1 "${mandir}/man1"
 inst_data configs/configuration.xml "${m2home}"
 
 
-while IFS== read -d' ' id path; do
-    exec >files-local-"${id}"
-    inst_data target/macros.fjava-"${id}" "${rpmmacrodir}"
+while IFS== read -d' ' java_id java_path; do
+    exec >files-local-"${java_id}"
+    inst_data target/macros.java-"${java_id}" "${rpmmacrodir}"
 done <<<"${jvms}"
 
 

--- a/install
+++ b/install
@@ -89,6 +89,7 @@ dir "${jnidir}"
 dir "${javadocdir}"
 dir "${mavenpomdir}"
 dir "${ivyxmldir}"
+dir "${jpbindingdir}"
 dir "${datadir}/maven-metadata"
 dir "${prefix}/lib/eclipse"
 dir "${prefix}/lib/eclipse/features"
@@ -125,6 +126,7 @@ inst_config target/eclipse.conf "${javaconfdir}"
 
 inst_data target/java-functions "${javadir}-utils"
 inst_exec java-utils/java-wrapper "${javadir}-utils"
+inst_exec target/jp_binding.sh "${javadir}-utils"
 
 inst_data target/macros.jpackage "${rpmmacrodir}"
 

--- a/java-utils/jp_binding.sh
+++ b/java-utils/jp_binding.sh
@@ -1,0 +1,226 @@
+#!/bin/sh
+# Copyright (c) 2024, Red Hat, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name of the Red Hat nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Authors:  Mikolaj Izdebski <mizdebsk@redhat.com>
+
+set -eu
+jpbindingdir="@{jpbindingdir}"
+
+if [ -z "${RPM_BUILD_ROOT:-}" ]; then
+    echo RPM_BUILD_ROOT env variable has not been set >&2
+    exit 1
+fi
+if [ -z "${RPM_SPECPARTS_DIR:-}" ]; then
+    echo RPM_BUILD_ROOT env variable has not been set >&2
+    exit 1
+fi
+
+rpmname=""
+basepkg=""
+pkg=""
+ghost=""
+target=""
+variant=""
+provides=""
+requires=""
+recommends=""
+with_meta_requires=true
+description=""
+with_description=true
+summary=""
+with_summary=true
+with_files=true
+with_package=true
+with_install=true
+verbose=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --rpm-name)
+            rpmname="$2"
+            shift
+            ;;
+        --base-pkg)
+            basepkg="$2"
+            shift
+            ;;
+        --binding-pkg)
+            pkg="$2"
+            shift
+            ;;
+        --ghost)
+            ghost="$2"
+            shift
+            ;;
+        --target)
+            target="$2"
+            shift
+            ;;
+        --variant)
+            variant="$2"
+            shift
+            ;;
+        --provides)
+            provides="${provides}
+Provides: $2"
+            shift
+            ;;
+        --requires)
+            requires="${requires}
+Requires: $2"
+            shift
+            ;;
+        --recommends)
+            recommends="${recommends}
+Recommends: $2"
+            shift
+            ;;
+        --no-meta-requires)
+            with_meta_requires=false
+            ;;
+        --description)
+            description="$2"
+            shift
+            ;;
+        --no-description)
+            with_description=false
+            ;;
+        --summary)
+            summary="$2"
+            shift
+            ;;
+        --no-summary)
+            with_summary=false
+            ;;
+        --no-files)
+            with_files=false
+            ;;
+        --no-package)
+            with_package=false
+            ;;
+        --no-install)
+            with_install=false
+            ;;
+        --verbose)
+            verbose=true
+            ;;
+        *)
+            echo "Unknown option $1" >&2
+            exit 1
+    esac
+    shift
+done
+
+debug()
+{
+    if ${verbose}; then
+        echo "$@" >&2
+    fi
+}
+
+if [ -z "${basepkg}" ]; then
+    if [ -n "${rpmname}" ]; then
+        basepkg="${rpmname}"
+        debug "Assuming default --base-pkg ${basepkg}"
+    else
+        echo "Missing required option --base-pkg" >&2
+        exit 1
+    fi
+fi
+
+if [ -z "${ghost}" ]; then
+    echo "Missing required option --ghost" >&2
+    exit 1
+fi
+
+if [ -z "${target}" ]; then
+    echo "Missing required option --target" >&2
+    exit 1
+fi
+
+if [ -z "${variant}" ]; then
+    echo "Missing required option --variant" >&2
+    exit 1
+fi
+
+if [ -z "${pkg}" ]; then
+    pkg="${basepkg}-${variant}"
+    debug "Assuming default --binding-pkg ${pkg}"
+fi
+
+if [ -z "${summary}" ]; then
+    summary="${basepkg} binding for ${variant}"
+fi
+
+if [ -z "${description}" ]; then
+    description="Configures ${basepkg} to work with ${variant}."
+fi
+
+sp=${RPM_SPECPARTS_DIR}/${pkg}.specpart
+: >${sp}
+
+if ${with_package}; then
+    echo "%package -n ${pkg}" >>${sp}
+    if ${with_summary}; then
+        echo "Summary: ${summary}" >>${sp}
+    fi
+    echo "${provides}" >>${sp}
+    echo "${requires}" >>${sp}
+    echo "${recommends}" >>${sp}
+    echo "Requires: javapackages-tools" >>${sp}
+    if ${with_meta_requires}; then
+        echo "Requires(meta): ${basepkg}" >>${sp}
+    fi
+    echo "" >>${sp}
+fi
+
+if ${with_description}; then
+    echo "%description -n ${pkg}" >>${sp}
+    echo "${description}" | fold >>${sp}
+    echo "" >>${sp}
+fi
+
+if ${with_files}; then
+    echo "%files -n ${pkg}" >>${sp}
+    echo "%ghost ${jpbindingdir}/${ghost}" >>${sp}
+    echo "%dir ${jpbindingdir}/${ghost}.d" >>${sp}
+    echo "${jpbindingdir}/${ghost}.d/${variant}" >>${sp}
+fi
+
+if ${verbose}; then
+    debug "Added the following package:"
+    sed 's/./    :: &/' ${sp} >&2
+fi
+
+if ${with_install}; then
+    install -d -m 755 ${RPM_BUILD_ROOT}${jpbindingdir}/${ghost}.d/
+    ln -sf ${target} ${RPM_BUILD_ROOT}${jpbindingdir}/${ghost}.d/${variant}
+fi

--- a/javapackages-tools.spec
+++ b/javapackages-tools.spec
@@ -19,8 +19,6 @@ BuildArch:      noarch
 
 Source:         https://github.com/fedora-java/javapackages/archive/%{version}.tar.gz
 
-Source21:       toolchains-openjdk21.xml
-
 BuildRequires:  coreutils
 BuildRequires:  make
 BuildRequires:  rubygem-asciidoctor
@@ -48,12 +46,12 @@ install their content.
 
 %package -n maven-local-openjdk21
 Summary:        Macros and scripts for Maven packaging support
-RemovePathPostfixes: -openjdk21
 Requires:       java-21-openjdk-devel
 Provides:       maven-local = %{version}-%{release}
 Requires:       %{name} = %{version}-%{release}
 Requires:       javapackages-local-openjdk21 = %{version}-%{release}
 Requires:       xmvn-minimal
+Requires:       xmvn-toolchain-openjdk21
 Requires:       mvn(org.fedoraproject.xmvn:xmvn-mojo)
 # Common Maven plugins required by almost every build. It wouldn't make
 # sense to explicitly require them in every package built with Maven.
@@ -147,9 +145,6 @@ rm -rf %{buildroot}%{_sysconfdir}/ivy
 rm -rf %{buildroot}%{_sysconfdir}/ant.d
 %endif
 
-mkdir -p %{buildroot}%{maven_home}/conf/
-cp -p %{SOURCE21} %{buildroot}%{maven_home}/conf/toolchains.xml-openjdk21
-
 %if 0%{?flatpak}
 # make both /app (runtime deps) and /usr (build-only deps) builds discoverable
 sed -e '/^JAVA_LIBDIR=/s|$|:/usr/share/java|' \
@@ -185,8 +180,6 @@ ln -s %{_datadir}/java-utils %{buildroot}%{_usr}/share/java-utils
 %files -n javapackages-local-openjdk21 -f files-local-openjdk21
 
 %files -n maven-local-openjdk21
-%dir %{maven_home}/conf
-%{maven_home}/conf/toolchains.xml-openjdk21
 
 %if %{with ivy}
 %files -n ivy-local -f files-ivy

--- a/macros.d/macros.javapackages-binding
+++ b/macros.d/macros.javapackages-binding
@@ -1,0 +1,2 @@
+# Home directory for Java @{java_id}
+%java_home @{java_home}

--- a/macros.d/macros.javapackages-filesystem
+++ b/macros.d/macros.javapackages-filesystem
@@ -80,3 +80,9 @@
 # Directory for Ivy XML files
 #
 %_ivyxmldir     %{_datadir}/ivy-xmls
+
+#
+# Directory containing binding symlinks
+# EXPERIMENTAL, subject to change or removal
+#
+%_jpbindingdir     %{_datadir}/jpbinding

--- a/macros.d/macros.jpackage
+++ b/macros.d/macros.jpackage
@@ -68,3 +68,10 @@ run "\\$@"\
 EOF\
 chmod 755 %{buildroot}%{_bindir}/%5\
 %{nil}
+
+
+#
+# Creates binding subpackages
+# EXPERIMENTAL, subject to change or removal
+#
+%jp_binding @{javadir}-utils/jp_binding.sh --rpm-name %{name}


### PR DESCRIPTION
Add new experimental `%jp_binding` macro for generating binding packages, which are typically used to configure Java applications such as Maven to run with particular JVM implementation, but the mechanism is generic and can be used for other things as well.

Unlike earlier implementations of binding packages, the new approach does not lead to creating conflicting packages.  Instead a hierarchy of symlinks is maintained, similarly to the alternatives system.
    
Currently there is no way to specify which binding will be selected in case when there is more than one installed (there is nothing like priorities yet), but this subject to change in the future.
    
The implementation of `%jp_binding` relies on "dynamic spec generation" (aka "specparts") feature of RPM 4.19, but later it could be updated to work with older RPM versions too.  More info in RPM docs: https://rpm-software-management.github.io/rpm/manual/dynamic_specs.html

Example usage:

```
%install
mkdir -p %{buildroot}/etc
echo JAVA_HOME=/opt/jvm/java-17-somejdk >%{buildroot}/etc/marvin-somejdk17.conf
echo JAVA_HOME=/opt/jvm/java-21-somejdk >%{buildroot}/etc/marvin-somejdk21.conf
touch %{buildroot}/etc/marvin-unbound.conf
ln -s %{_jpbindingdir}/marvin.conf %{buildroot}/etc/marvin.conf

%jp_binding --provides marvin-jdk-binding \
            --base-pkg marvin \
 	    --variant unbound \
 	    --ghost marvin.conf \
 	    --target /etc/marvin-unbound.conf

# bindings can be also added in a loop
for jdk in 17 21; do
  %jp_binding --provides marvin-jdk-binding \
              --base-pkg marvin \
	      --variant somejdk${jdk} \
	      --ghost marvin.conf \
	      --target /etc/marvin-somejdk${jdk}.conf \
	      --requires somejdk-${jdk}-headless \
	      --recommends somejdk-${jdk}-devel
done

%files
%config /etc/marvin*.conf
```