### PR TITLE
Replace invalid \$ escape in regex

### DIFF
--- a/python/javapackages/maven/artifact.py
+++ b/python/javapackages/maven/artifact.py
@@ -191,7 +191,7 @@ class AbstractArtifact(object):
                getattr(self, member) and
                isinstance(getattr(self, member), str)):
                     curr_value = getattr(self, member)
-                    prog = re.compile("\$\{([^}]+)\}")
+                    prog = re.compile("\\$\{([^}]+)\}")
                     props = prog.findall(curr_value)
                     for key in props:
                         try:


### PR DESCRIPTION
Replace \$ with \\$ to avoid SyntaxWarning in Python 3.14.

Resolves [rhbz#2376187](https://bugzilla.redhat.com/show_bug.cgi?id=2376187)